### PR TITLE
Speed-up Sync process

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -547,7 +547,7 @@ sub getsnaps() {
 
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
 
-	my $getsnapcmd = "$rhost $zfscmd get -Hp creation |";
+	my $getsnapcmd = "$rhost $zfscmd get -Hpr creation $fs |";
 	if ($debug) { print "DEBUG: getting list of snapshots on $fs...\n"; }
 	open FH, $getsnapcmd;
 	my @rawsnaps = <FH>;


### PR DESCRIPTION
This is a simple change which speeds up Sync process on systems with a high amount of Snapshots. It gets only Snapshots desired for the targeted FS and reduces output and thus Parsing time of the get command in the first place, and schould greatly reduce later processes (sorting arrays, mathing snaps) due to the reduced overhead.