### PR TITLE
didnt grab the right one 1st time

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -547,7 +547,7 @@ sub getsnaps() {
 
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
 
-	my $getsnapcmd = "$rhost $zfscmd get -Hpr creation $fs |";
+	my $getsnapcmd = "$rhost $zfscmd get -Hpd 1 creation $fs |";
 	if ($debug) { print "DEBUG: getting list of snapshots on $fs...\n"; }
 	open FH, $getsnapcmd;
 	my @rawsnaps = <FH>;


### PR DESCRIPTION
this one reduces depth of the get command to 1 so zfs get wont pull subsequent dataset snapshots.