### PR TITLE
Also check for 'zfs receive' alias

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -1006,7 +1006,7 @@ sub iszfsbusy {
 
         foreach my $process (@processes) {
 		# if ($args{'debug'}) { print "DEBUG: checking process $process...\n"; }
-                if ($process =~ /zfs *(send|receive).*$fs/) {
+                if ($process =~ /zfs *(send|receive|recv).*$fs/) {
                         # there's already a zfs send/receive process for our target filesystem - return true
                         # if ($args{'debug'}) { print "DEBUG: process $process matches target $fs!\n"; }
                         return 1;

--- a/syncoid
+++ b/syncoid
@@ -466,7 +466,7 @@ sub iszfsbusy {
 
 	foreach my $process (@processes) {
 		# if ($debug) { print "DEBUG: checking process $process...\n"; }
-		if ($process =~ /zfs receive.*$fs/) {
+		if ($process =~ /zfs *(receive|recv).*$fs/) {
 			# there's already a zfs receive process for our target filesystem - return true
 			if ($debug) { print "DEBUG: process $process matches target $fs!\n"; }
 			return 1;


### PR DESCRIPTION
When checking the currently running processes for zfs send & receive activity, also check the `recv` alias.