### PR TITLE
Use UNIX-style 'ps' options everywhere for compatibility

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -928,7 +928,7 @@ sub checklock {
 		return 2;
 	}
 
-	open PL, "$pscmd p $lockpid -o args= |";
+	open PL, "$pscmd -p $lockpid -o args= |";
 	my @processlist = <PL>;
 	close PL;
 
@@ -980,7 +980,7 @@ sub writelock {
 
 	my $pid = $$;
 	
-	open PL, "$pscmd p $$ -o args= |";
+	open PL, "$pscmd -p $$ -o args= |";
 	my @processlist = <PL>;
 	close PL;
 	
@@ -998,9 +998,9 @@ sub iszfsbusy {
 	# return true if busy (currently being sent or received), return false if not.
 
         my $fs = shift;
-        # if (args{'debug'}) { print "DEBUG: checking to see if $fs on is already in zfs receive using $pscmd axo args= ...\n"; }
+        # if (args{'debug'}) { print "DEBUG: checking to see if $fs on is already in zfs receive using $pscmd -Ao args= ...\n"; }
 
-        open PL, "$pscmd axo args= |";
+        open PL, "$pscmd -Ao args= |";
         my @processes = <PL>;
         close PL;
 

--- a/syncoid
+++ b/syncoid
@@ -458,9 +458,9 @@ sub checkcommands {
 sub iszfsbusy {
 	my ($rhost,$fs,$isroot) = @_;
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
-	if ($debug) { print "DEBUG: checking to see if $fs on $rhost is already in zfs receive using $rhost $pscmd axo args= ...\n"; }
+	if ($debug) { print "DEBUG: checking to see if $fs on $rhost is already in zfs receive using $rhost $pscmd -Ao args= ...\n"; }
 
-	open PL, "$rhost $pscmd axo args= |";
+	open PL, "$rhost $pscmd -Ao args= |";
 	my @processes = <PL>;
 	close PL;
 


### PR DESCRIPTION
Hopefully fixes #17 without the need for OS compatibility checking. Tested `ps` options on SmartOS, Ubuntu 14.04, and FreeBSD 10.2. The FreeBSD man page does not document the '-A' option, but the binary supported it with identical output.