### PR TITLE
Bug correction in 'getsnaps'

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -798,11 +798,9 @@ sub getsnaps() {
 		if ($line =~ /$fs\@/) {
 			chomp $line;
 			my $ctime = $line;
-			$ctime =~ s/^.*creation\s*//;
-			$ctime =~ s/\s*-$//;
+			$ctime =~ s/^.*\screation\s*(\d*).*/$1/;
 			my $snap = $line;
-			$snap =~ s/\s*creation.*$//;
-			$snap =~ s/^\S*\@//;
+			$snap =~ s/^\S*\@(\S*)\s*creation.*$/$1/;
 			$snaps{$type}{$snap}{'ctime'}=$ctime;
 		}
 	}


### PR DESCRIPTION
getsnaps not working when dataset name contains 'creation'