### PR TITLE
Fix #91: do not use exit codes > 255

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -764,7 +764,7 @@ sub getmatchingsnapshot {
 		print "                replication must be to a NON EXISTENT DATASET, which will\n";
 		print "                then be CREATED BY the initial replication process.\n\n";
 	}
-	exit 256;
+	exit 3;
 }
 
 sub newsyncsnap {


### PR DESCRIPTION
Exit codes > 256 are treated by bash as `exit_code % 256`, which is confusing. Furthermore, using code 256 is particularly problematic, as 256%256=0, which means success, and is not was was intended here.

For further information about special exit codes, see http://tldp.org/LDP/abs/html/exitcodes.html.