### PR TITLE
Update INSTALL to reflect crypto changes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,9 +2,10 @@ SYNCOID
 -------
 Syncoid depends on ssh, pv, gzip, lzop, and mbuffer.  It can run with reduced 
 functionality in the absence of any or all of the above. SSH is only required
-for remote synchronization.  Arcfour crypto is the default for SSH transport,
-and currently (v1.4.5) syncoid runs will fail if arcfour is not available
-on either end of the transport.
+for remote synchronization.  On newer FreeBSD and Ubuntu Xenial 
+chacha20-poly1305@openssh.com, on other distributions arcfour crypto is the 
+default for SSH transport since v1.4.6. Syncoid runs will fail if one of them 
+is not available on either end of the transport.
 
 On Ubuntu: apt install pv lzop mbuffer
 On FreeBSD: pkg install pv lzop


### PR DESCRIPTION
In v1.4.6 Xenial and newer FreeBSD changes was added.
Change INSTALL to reflect them so it cannot mislead users about requirements.