### PR TITLE
add sshcipher option

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -45,6 +45,9 @@ my $lscmd = '/bin/ls';
 if ( $args{'sshport'} ) {
   $sshport = "-p $args{'sshport'}";
 }
+if ( $args{'sshcipher'} ) {
+  $sshcipher = "-c $args{'sshcipher'}";
+}
 # figure out if source and/or target are remote.
 if ( $args{'sshkey'} ) {
   $sshcmd = "$sshcmd $sshcipher $sshport -i $args{'sshkey'}";
@@ -311,7 +314,7 @@ sub getargs {
 
 	my %novaluearg;
 	my %validarg;
-	push my @validargs, ('debug','nocommandchecks','version','monitor-version','compress','source-bwlimit','target-bwlimit','dumpsnaps','recursive','r','sshkey','sshport','quiet','no-stream','no-sync-snap');
+	push my @validargs, ('debug','nocommandchecks','version','monitor-version','compress','source-bwlimit','target-bwlimit','dumpsnaps','recursive','r','sshcipher','sshkey','sshport','quiet','no-stream','no-sync-snap');
 	foreach my $item (@validargs) { $validarg{$item} = 1; }
 	push my @novalueargs, ('debug','nocommandchecks','version','monitor-version','dumpsnaps','recursive','r','quiet','no-stream','no-sync-snap');
 	foreach my $item (@novalueargs) { $novaluearg{$item} = 1; }


### PR DESCRIPTION
It makes possible to use or even force alternative ssh ciphers.
AES ciphers are more secure and produce similar speed if it's supported by the CPU.
See https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Security_Guide/sect-Security_Guide-Encryption-OpenSSL_Intel_AES-NI_Engine.html