### PR TITLE
Explicit LXD support

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -212,7 +212,7 @@ sub prune_snapshots {
 				# print "snap $path\@$snap has age $snaps{$path}{$snap}{'ctime'}, maxage is $maxage.\n";
 				if ( ($snaps{$path}{$snap}{'ctime'} < $maxage) && ($numsnapsthistype > $minsnapsthistype) ) {
 					if ( $islxd ) {
-					    push(@prunesnaps, "$lxc delete $section/snap");
+					    push(@prunesnaps, "$lxc delete $section/$snap");
 					} else {
 					    push(@prunesnaps, "$zfs destroy $path\@$snap");
 					}
@@ -523,7 +523,6 @@ sub getsnaps {
 	foreach my $snap (@rawsnaps) {
 		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*ly)\s*creation\s*(\d*)/);
 		my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
-#		if ($snapname =~ /^autosnap/) {
 		if ($snapname =~ /(^snapshot-)*autosnap/) {
 			$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 			$snaps{$fs}{$snapname}{'type'}=$snaptype;

--- a/sanoid
+++ b/sanoid
@@ -524,7 +524,10 @@ sub getsnaps {
 		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*ly)\s*creation\s*(\d*)/);
 		my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
 		if ($snapname =~ /(^snapshot-)*autosnap/) {
-			$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
+		        if ($snapname =~ /^snapshot-/) {
+			        $snapname = substr $snapname, 9;
+			}
+		        $snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 			$snaps{$fs}{$snapname}{'type'}=$snaptype;
 		}
 	}

--- a/sanoid
+++ b/sanoid
@@ -18,6 +18,7 @@ my %args = getargs(@ARGV);
 my $pscmd = '/bin/ps';
 
 my $zfs = '/sbin/zfs';
+my $lxc = '/usr/bin/lxc';
 
 if ($args{'configdir'} eq '') { $args{'configdir'} = '/etc/sanoid'; }
 my $conf_file = "$args{'configdir'}/sanoid.conf";
@@ -181,6 +182,8 @@ sub prune_snapshots {
 		if (! $config{$section}{'autoprune'}) { next; }
 		if ($config{$section}{'process_children_only'}) { next; }
 
+		my $islxd = ($config{$section}{'lxd'});
+
 		my $path = $config{$section}{'path'};
 
 		my $period = 0;
@@ -208,8 +211,11 @@ sub prune_snapshots {
 			foreach my $snap( @sorted ){
 				# print "snap $path\@$snap has age $snaps{$path}{$snap}{'ctime'}, maxage is $maxage.\n";
 				if ( ($snaps{$path}{$snap}{'ctime'} < $maxage) && ($numsnapsthistype > $minsnapsthistype) ) {
-					my $fullpath = $path . '@' . $snap;
-					push(@prunesnaps,$fullpath);
+					if ( $islxd ) {
+					    push(@prunesnaps, "$lxc delete $section/snap");
+					} else {
+					    push(@prunesnaps, "$zfs destroy $path\@$snap");
+					}
 					# we just got rid of a snap, so we now have one fewer, duh
 					$numsnapsthistype--;
 				}
@@ -224,7 +230,7 @@ sub prune_snapshots {
 						if (iszfsbusy($path)) {
 							print "INFO: deferring pruning of $snap - $path is currently in zfs send or receive.\n";
 						} else {
-							if (! $args{'readonly'}) { system($zfs, "destroy",$snap) == 0 or die "could not remove $snap : $?"; }
+							if (! $args{'readonly'}) { system($snap) == 0 or die "could not remove $snap : $?"; }
 						}
 					}
 					removelock('sanoid_pruning');
@@ -253,13 +259,15 @@ sub take_snapshots {
 	my $forcecacheupdate = 0;
 
 	my @newsnaps;
-
+	
 	if ($args{'verbose'}) { print "INFO: taking snapshots...\n"; }
 	foreach my $section (keys %config) {
 		if ($section =~ /^template/) { next; }
 		if (! $config{$section}{'autosnap'}) { next; }
 		if ($config{$section}{'process_children_only'}) { next; }		
 
+		my $islxd = ($config{$section}{'lxd'});
+		
 		my $path = $config{$section}{'path'};
 
 		foreach my $type (keys %{ $config{$section} }){
@@ -322,7 +330,11 @@ sub take_snapshots {
 					# update to most current possible datestamp
 					%datestamp = get_date();
 					# print "we should have had a $type snapshot of $path $maxage seconds ago; most recent is $newestage seconds old.\n";
-					push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}_$type");
+					if ( $islxd ) {
+					    push(@newsnaps, "$lxc snapshot $section autosnap_$datestamp{'sortable'}_$type");
+					} else {
+					    push(@newsnaps, "$zfs snapshot $path\@autosnap_$datestamp{'sortable'}_$type");
+					}
 				}
 			}
 		}
@@ -332,10 +344,10 @@ sub take_snapshots {
 		foreach my $snap ( @newsnaps ) {
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) { 
-				system($zfs, "snapshot", "$snap") == 0
-					or die "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
+				system($snap) == 0
+				    or die "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
 				# make sure we don't end up with multiple snapshots with the same ctime
-				sleep 1;
+			        sleep 1;
 			}
 		}
 		$forcecacheupdate = 1;
@@ -511,7 +523,8 @@ sub getsnaps {
 	foreach my $snap (@rawsnaps) {
 		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*ly)\s*creation\s*(\d*)/);
 		my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
-		if ($snapname =~ /^autosnap/) {
+#		if ($snapname =~ /^autosnap/) {
+		if ($snapname =~ /(^snapshot-)*autosnap/) {
 			$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 			$snaps{$fs}{$snapname}{'type'}=$snaptype;
 		}
@@ -535,7 +548,7 @@ sub init {
 	tie my %ini, 'Config::IniFiles', ( -file => $conf_file ) or die "FATAL: cannot load $conf_file - please create a valid local config file before running sanoid!";
 
 	# we'll use these later to normalize potentially true and false values on any toggle keys
-	my @toggles = ('autosnap','autoprune','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only');
+	my @toggles = ('autosnap','autoprune','lxd','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only');
 	my @istrue=(1,"true","True","TRUE","yes","Yes","YES","on","On","ON");
 	my @isfalse=(0,"false","False","FALSE","no","No","NO","off","Off","OFF");
 	

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -27,8 +27,17 @@
 	# only override the values already set by the parent template, not replace it completely.
 	use_template = demo
 
+# You can maintain snaps of LXD containers using native lxc utility
+# Name the module as the container
+[container1]
+	# Templates are supported
+	use_template = production
 
+	# Full path MUST be given
+	path = zpoolname/lxdpoolname/containers/container1
 
+	# Recursion is NOT supported
+	recursive = no
 
 #############################
 # templates below this line #
@@ -44,8 +53,8 @@
 	daily = 30
 	monthly = 3
 	yearly = 0
-	autosnap = yes
-	autoprune = yes
+	autosnap = no
+	autoprune = no
 
 [template_backup]
 	autoprune = yes
@@ -54,17 +63,18 @@
 	monthly = 12
 	yearly = 0
 
-	### don't take new snapshots - snapshots on backup 
+	### don't take new snapshots - snapshots on backup
 	### datasets are replicated in from source, not
 	### generated locally
 	autosnap = no
 
-	### monitor hourlies and dailies, but don't warn or 
-	### crit until they're over 48h old, since replication 
+	### monitor hourlies and dailies, but don't warn or
+	### crit until they're over 48h old, since replication
 	### is typically daily only
 	hourly_warn = 2880
 	hourly_crit = 3600
 	daily_warn = 48
 	daily_crit = 60
+
 
 

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -56,8 +56,8 @@
 	daily = 30
 	monthly = 3
 	yearly = 0
-	autosnap = no
-	autoprune = no
+	autosnap = yes
+	autoprune = yes
 
 [template_backup]
 	autoprune = yes

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -30,6 +30,9 @@
 # You can maintain snaps of LXD containers using native lxc utility
 # Name the module as the container
 [container1]
+	# Indicate that this is and LXD container
+	lxd = yes
+	
 	# Templates are supported
 	use_template = production
 

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -27,6 +27,7 @@ daily = 90
 monthly = 6
 yearly = 0
 min_percent_free = 10
+lxd = no
 
 # We will automatically take snapshots if autosnap is on, at the desired times configured
 # below (or immediately, if we don't have one since the last preferred time for that type).


### PR DESCRIPTION
I've hacked together some code to support LXD container snapshotting in Sanoid. It uses the lxc client utility to do the snapshots instead of zfs utility to avoid confusing LXD. First time using GitHub and very green in perl, so please bear with me.