### PR TITLE
Add '--no-privilege-elevation' option to bypass root check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 	This prints a list of snapshots during the run.
 
++ --no-privilege-elevation
+
+	Bypass the root check and assume syncoid has the necessary permissions (for use with ZFS permission delegation).
+
 + --sshport
 
 	Allow sync to/from boxes running SSH on non-standard ports.

--- a/syncoid
+++ b/syncoid
@@ -20,7 +20,7 @@ my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
                    "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
-                   "no-clone-handling") or pod2usage(2);
+                   "no-clone-handling", "no-privilege-elevation") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -1186,7 +1186,7 @@ sub getssh {
 		$rhost =~ s/:\Q$fs\E$//;
 		my $remoteuser = $rhost;
 		 $remoteuser =~ s/\@.*$//;
-		if ($remoteuser eq 'root') { $isroot = 1; } else { $isroot = 0; }
+		if ($remoteuser eq 'root' || $args{'no-privilege-elevation'}) { $isroot = 1; } else { $isroot = 0; }
 		# now we need to establish a persistent master SSH connection
 		$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
 		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
@@ -1194,7 +1194,7 @@ sub getssh {
 		$rhost = "-S $socket $rhost";
 	} else {
 		my $localuid = $<;
-		if ($localuid == 0) { $isroot = 1; } else { $isroot = 0; }
+		if ($localuid == 0 || $args{'no-privilege-elevation'}) { $isroot = 1; } else { $isroot = 0; }
 	}
 	# if ($isroot) { print "this user is root.\n"; } else { print "this user is not root.\n"; }
 	return ($rhost,$fs,$isroot);
@@ -1455,3 +1455,4 @@ Options:
   --no-command-checks   Do not check command existence before attempting transfer. Not recommended
   --no-resume           Don't use the ZFS resume feature if available
   --no-clone-handling   Don't try to recreate clones on target
+  --no-privilege-elevation  Bypass the root check, for use with ZFS permission delegation


### PR DESCRIPTION
This PR is designed to implement #139. It adds a `--no-privilege-elevation` option that bypasses the root check on both the source and destination. If you want, I can add separate control of the source and destination checks, or rename the option to something else.