### PR TITLE
Update RPM Spec

### DIFF
--- a/sanoid.spec
+++ b/sanoid.spec
@@ -110,7 +110,7 @@ echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}
 %endif
 
 %changelog
-* Wed Aug 30 2017 Dominic Robinson <github@dcrdev.com> - 1.4.14-2
+* Thu Aug 31 2017 Dominic Robinson <github@dcrdev.com> - 1.4.14-2
 - Add systemd timers
 * Wed Aug 30 2017 Dominic Robinson <github@dcrdev.com> - 1.4.14-1
 - Version bump

--- a/sanoid.spec
+++ b/sanoid.spec
@@ -1,17 +1,25 @@
-%global version 1.4.13
+%global version 1.4.14
 %global git_tag v%{version}
 
-Name:		sanoid
-Version:	%{version}
-Release:	1%{?dist}
-BuildArch:	noarch
-Summary:	A policy-driven snapshot management tool for ZFS file systems
-Group:		Applications/System
-License:	GPLv3
-URL:		https://github.com/jimsalterjrs/sanoid
-Source0:  https://github.com/jimsalterjrs/%{name}/archive/%{git_tag}/%{name}-%{version}.tar.gz
-#BuildRequires:	
-Requires:	perl, mbuffer, lzop, pv
+# Enable with systemctl "enable sanoid.timer"
+%global _with_systemd 1
+
+Name:		   sanoid
+Version:	   %{version}
+Release:	   2%{?dist}
+BuildArch:	   noarch
+Summary:	   A policy-driven snapshot management tool for ZFS file systems
+Group:		   Applications/System
+License:	   GPLv3
+URL:		   https://github.com/jimsalterjrs/sanoid
+Source0:       https://github.com/jimsalterjrs/%{name}/archive/%{git_tag}/%{name}-%{version}.tar.gz
+
+Requires:	   perl, mbuffer, lzop, pv
+%if 0%{?_with_systemd}
+Requires:      systemd >= 212
+
+BuildRequires: systemd
+%endif
 
 %description
 Sanoid is a policy-driven snapshot management
@@ -24,20 +32,62 @@ human-readable TOML configuration file.
 %setup -q
 
 %build
+echo "Nothing to build"
 
 %install
 %{__install} -D -m 0644 sanoid.defaults.conf %{buildroot}/etc/sanoid/sanoid.defaults.conf
 %{__install} -d %{buildroot}%{_sbindir}
 %{__install} -m 0755 sanoid syncoid findoid sleepymutex %{buildroot}%{_sbindir}
 
+%if 0%{?_with_systemd}
+%{__install} -d %{buildroot}%{_unitdir}
+%endif
+
 %if 0%{?fedora}
 %{__install} -D -m 0644 sanoid.conf %{buildroot}%{_docdir}/%{name}/examples/sanoid.conf
-echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}/examples/sanoid.cron
 %endif
 %if 0%{?rhel}
 %{__install} -D -m 0644 sanoid.conf %{buildroot}%{_docdir}/%{name}-%{version}/examples/sanoid.conf
+%endif
+
+%if 0%{?_with_systemd}
+cat > %{buildroot}%{_unitdir}/%{name}.service <<EOF
+[Unit]
+Description=Snapshot ZFS Pool
+Requires=zfs.target
+After=zfs.target
+
+[Service]
+Type=oneshot
+ExecStart=%{_sbindir}/sanoid --cron
+EOF
+
+cat > %{buildroot}%{_unitdir}/%{name}.timer <<EOF
+[Unit]
+Description=Run Sanoid Every Minute
+
+[Timer]
+OnCalendar=*:0/1
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+%else
+%if 0%{?fedora}
+%{__install} -D -m 0644 sanoid.conf %{buildroot}%{_docdir}/%{name}/examples/sanoid.conf
+%endif
+%if 0%{?rhel}
 echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}-%{version}/examples/sanoid.cron
 %endif
+%endif
+
+%post
+%{?_with_systemd:%{_bindir}/systemctl daemon-reload}
+
+%postun
+%{?_with_systemd:%{_bindir}/systemctl daemon-reload}
 
 %files
 %doc CHANGELIST VERSION README.md FREEBSD.readme
@@ -54,8 +104,16 @@ echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}
 %if 0%{?rhel}
 %{_docdir}/%{name}-%{version}
 %endif
+%if 0%{?_with_systemd}
+%{_unitdir}/%{name}.service
+%{_unitdir}/%{name}.timer
+%endif
 
 %changelog
+* Wed Aug 30 2017 Dominic Robinson <github@dcrdev.com> - 1.4.14-2
+- Add systemd timers
+* Wed Aug 30 2017 Dominic Robinson <github@dcrdev.com> - 1.4.14-1
+- Version bump
 * Wed Jul 12 2017 Thomas M. Lapp <tmlapp@gmail.com> - 1.4.13-1
 - Version bump
 - Include FREEBSD.readme in docs


### PR DESCRIPTION
This pull request bumps the version number within the rpm spec file, additionally it introduces the addition of systemd timers. This is convenient because it means the user can activate sanoid out of the box via "systemctl enable sanoid.timer".

By default the timer is set to run every minute, but this can be overridden by copying the unit and timer into /etc/systemd/system and making the appropriate changes.

The systemd timers are entirely optional within the spec itself, they can be toggled on/off with the _with_systemd variable.