### PR TITLE
Adds support for zfs send -c, and a few other efficiency improvements for special cases.

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -82,6 +82,8 @@ if (!defined $targethost) { $targethost = ''; }
 my $sourcesudocmd = $sourceisroot ? '' : $sudocmd;
 my $targetsudocmd = $targetisroot ? '' : $sudocmd;
 
+my $send_compressed = $args{'compress'} eq 'zfs' ? ' -c ' : '';
+
 # figure out whether compression, mbuffering, pv
 # are available on source, target, local machines.
 # warn user of anything missing, then continue with sync.
@@ -216,7 +218,7 @@ sub syncdataset {
 		# if --no-stream is specified, our full needs to be the newest snapshot, not the oldest.
 		if (defined $args{'no-stream'}) { $oldestsnap = getnewestsnapshot(\%snaps); }
 
-		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefs\@$oldestsnap";
+		my $sendcmd = "$sourcesudocmd $zfscmd send $send_compressed $sourcefs\@$oldestsnap";
 		my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfs";
 
 		my $pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap",0,$sourceisroot);
@@ -252,7 +254,7 @@ sub syncdataset {
 			# $originaltargetreadonly = getzfsvalue($targethost,$targetfs,$targetisroot,'readonly');
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly','on');
 
-			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefs\@$oldestsnap $sourcefs\@$newsyncsnap";
+			$sendcmd = "$sourcesudocmd $zfscmd send $send_compressed $args{'streamarg'} $sourcefs\@$oldestsnap $sourcefs\@$newsyncsnap";
 			$pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			$disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -319,7 +321,7 @@ sub syncdataset {
 				system ("$targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap");
 			}
 
-			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefs\@$matchingsnap $sourcefs\@$newsyncsnap";
+			my $sendcmd = "$sourcesudocmd $zfscmd send $send_compressed $args{'streamarg'} $sourcefs\@$matchingsnap $sourcefs\@$newsyncsnap";
 			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfs";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);
@@ -354,6 +356,12 @@ sub compressargset {
 			decomrawcmd => '',
 			decomargs   => '',
 		},
+		'zfs' => {
+			rawcmd      => '',
+			args        => '',
+			decomrawcmd => '',
+			decomargs   => '',
+		},
 		'gzip' => {
 			rawcmd      => '/bin/gzip',
 			args        => '-3',
@@ -382,7 +390,7 @@ sub compressargset {
 
 	if ($value eq 'default') {
 		$value = $DEFAULT_COMPRESSION;
-	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'lzo', 'default', 'none'))) {
+	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'lzo', 'zfs', 'default', 'none'))) {
 		warn "Unrecognised compression value $value, defaulting to $DEFAULT_COMPRESSION";
 		$value = $DEFAULT_COMPRESSION;
 	}
@@ -896,7 +904,7 @@ sub getsendsize {
 	my $sourcessh;
 	if ($sourcehost ne '') { $sourcessh = "$sshcmd $sourcehost"; } else { $sourcessh = ''; }
 
-	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send -nP $snaps";
+	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send $send_compressed -nP $snaps";
 	if ($debug) { print "DEBUG: getting estimated transfer size from source $sourcehost using \"$getsendsizecmd 2>&1 |\"...\n"; }
 
 	open FH, "$getsendsizecmd 2>&1 |";
@@ -955,7 +963,8 @@ syncoid - ZFS snapshot replication tool
 
 Options:
 
-  --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, lzo (default) & none
+  --compress=FORMAT     Compresses data during transfer. Currently accepted options: gzip, pigz-fast, pigz-slow, lzo (default), zfs & none
+												--compress=zfs will use zfs send -c for pool-to-pool compression (avoids decompression/recompression inefficiency)
   --recursive|r         Also transfers child datasets
   --source-bwlimit=<limit k|m|g|t>  Bandwidth limit on the source transfer
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer

--- a/syncoid
+++ b/syncoid
@@ -76,6 +76,9 @@ if ($debug) { print "DEBUG: SSHCMD: $sshcmd\n"; }
 my ($sourcehost,$sourcefs,$sourceisroot) = getssh($rawsourcefs);
 my ($targethost,$targetfs,$targetisroot) = getssh($rawtargetfs);
 
+if (!defined $sourcehost) { $sourcehost = ''; }
+if (!defined $targethost) { $targethost = ''; }
+
 my $sourcesudocmd = $sourceisroot ? '' : $sudocmd;
 my $targetsudocmd = $targetisroot ? '' : $sudocmd;
 
@@ -408,9 +411,6 @@ sub checkcommands {
 		$avail{'targetmbuffer'} = 1;
 		return %avail;
 	}
-
-	if (!defined $sourcehost) { $sourcehost = ''; }
-	if (!defined $targethost) { $targethost = ''; }
 
 	if ($sourcehost ne '') { $sourcessh = "$sshcmd $sourcehost"; } else { $sourcessh = ''; }
 	if ($targethost ne '') { $targetssh = "$sshcmd $targethost"; } else { $targetssh = ''; }

--- a/syncoid
+++ b/syncoid
@@ -83,6 +83,9 @@ my ($targethost,$targetfs,$targetisroot) = getssh($rawtargetfs);
 if (!defined $sourcehost) { $sourcehost = ''; }
 if (!defined $targethost) { $targethost = ''; }
 
+#print "source: $sourcehost:$sourcefs; target: $targethost:$targetfs\n";
+#exit 0;
+
 my $sourcesudocmd = $sourceisroot ? '' : $sudocmd;
 my $targetsudocmd = $targetisroot ? '' : $sudocmd;
 
@@ -246,7 +249,7 @@ sub syncdataset {
 			return 0;
 		}
 		system($synccmd) == 0
-			or die "CRITICAL ERROR: $synccmd failed: $?";
+			or die "CRITICAL ERROR: $synccmd failed: $!";
 
 		# now do an -I to the new sync snapshot, assuming there were any snapshots
 		# other than the new sync snapshot to begin with, of course - and that we
@@ -826,10 +829,15 @@ sub getssh {
 		$rhost = $fs;
 		$fs =~ s/^\S*\@\S*://;
 		$rhost =~ s/:$fs$//;
-		my $remoteuser = $rhost;
-		 $remoteuser =~ s/\@.*$//;
+		my ($remoteuser,$remotehost) = split('@',$rhost);
+#		my $remoteuser = $rhost;
+#		$remoteuser =~ s/\@.*$//;
 		if ($remoteuser eq 'root') { $isroot = 1; } else { $isroot = 0; }
-		if (!defined $args{'rsh'}) {
+
+		if (defined $args{'rsh'}) {
+			# rsh doesn't understand user@host 
+			$rhost = "-l $remoteuser $remotehost"
+		} else {
 		  # now we need to establish a persistent master SSH connection
 			$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
 			open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
@@ -972,7 +980,7 @@ syncoid - ZFS snapshot replication tool
 Options:
 
   --compress=FORMAT     Compresses data during transfer. Currently accepted options: gzip, pigz-fast, pigz-slow, lzo (default), zfs & none
-												--compress=zfs will use zfs send -c for pool-to-pool compression (avoids decompression/recompression inefficiency)
+                        --compress=zfs will use zfs send -c for pool-to-pool compression (avoids decompression/recompression inefficiency)
   --recursive|r         Also transfers child datasets
   --source-bwlimit=<limit k|m|g|t>  Bandwidth limit on the source transfer
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer
@@ -992,4 +1000,4 @@ Options:
   --dumpsnaps           Dumps a list of snapshots during the run
   --no-command-checks   Do not check command existence before attempting transfer. Not recommended
   --direct              Disable external compression, buffering, and progress view
-  --rsh									Use rsh instead of ssh (to avoid encryption overhead)
+  --rsh                 Use rsh instead of ssh (to avoid encryption overhead)

--- a/syncoid
+++ b/syncoid
@@ -19,7 +19,7 @@ use Sys::Hostname;
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap") or pod2usage(2);
+                   "debug", "quiet", "no-stream", "no-sync-snap", "direct") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -85,6 +85,7 @@ my $targetsudocmd = $targetisroot ? '' : $sudocmd;
 # figure out whether compression, mbuffering, pv
 # are available on source, target, local machines.
 # warn user of anything missing, then continue with sync.
+# --direct, --no-command-checks are evaluated here
 my %avail = checkcommands();
 
 my %snaps;
@@ -409,6 +410,17 @@ sub checkcommands {
 		$avail{'localmbuffer'} = 1;
 		$avail{'sourcembuffer'} = 1;
 		$avail{'targetmbuffer'} = 1;
+		return %avail;
+	}
+
+  # if --direct then disable all of these
+	if ($args{'direct'}) {
+		if ($debug) { print "DEBUG: Disabling compression, buffering, and progress view due to --direct\n"; }
+		$avail{'compress'} = 0;
+		$avail{'localpv'} = 0;
+		$avail{'localmbuffer'} = 0;
+		$avail{'sourcembuffer'} = 0;
+		$avail{'targetmbuffer'} = 0;
 		return %avail;
 	}
 
@@ -962,3 +974,4 @@ Options:
   --quiet               Suppresses non-error output
   --dumpsnaps           Dumps a list of snapshots during the run
   --no-command-checks   Do not check command existence before attempting transfer. Not recommended
+  --direct              Disable external compression, buffering, and progress view

--- a/syncoid
+++ b/syncoid
@@ -19,7 +19,7 @@ use Sys::Hostname;
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap", "direct") or pod2usage(2);
+                   "debug", "quiet", "no-stream", "no-sync-snap", "direct", "rsh") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -48,7 +48,6 @@ my $debug = $args{'debug'};
 my $quiet = $args{'quiet'};
 
 my $zfscmd = '/sbin/zfs';
-my $sshcmd = '/usr/bin/ssh';
 my $pscmd = '/bin/ps';
 
 my $pvcmd = '/usr/bin/pv';
@@ -59,19 +58,24 @@ my $mbufferoptions = '-q -s 128k -m 16M 2>/dev/null';
 # being present on remote machines.
 my $lscmd = '/bin/ls';
 
-if (length $args{'sshcipher'}) {
-	$args{'sshcipher'} = "-c $args{'sshcipher'}";
+my $sshcmd = (defined $args{'rsh'} ? '/usr/bin/rsh' : '/usr/bin/ssh');
+
+if (!defined $args{'rsh'}) {
+  if (length $args{'sshcipher'}) {
+  	$args{'sshcipher'} = "-c $args{'sshcipher'}";
+  }
+  if (length $args{'sshport'}) {
+    $args{'sshport'} = "-p $args{'sshport'}";
+  }
+  if (length $args{'sshkey'}) {
+  	$args{'sshkey'} = "-i $args{'sshkey'}";
+  }
+  my $sshoptions = join " ", map { "-o " . $_ } @{$args{'sshoption'}}; # deref required
+  
+  $sshcmd = "$sshcmd $args{'sshcipher'} $sshoptions $args{'sshport'} $args{'sshkey'}";
 }
-if (length $args{'sshport'}) {
-  $args{'sshport'} = "-p $args{'sshport'}";
-}
-if (length $args{'sshkey'}) {
-	$args{'sshkey'} = "-i $args{'sshkey'}";
-}
-my $sshoptions = join " ", map { "-o " . $_ } @{$args{'sshoption'}}; # deref required
 
 # figure out if source and/or target are remote.
-$sshcmd = "$sshcmd $args{'sshcipher'} $sshoptions $args{'sshport'} $args{'sshkey'}";
 if ($debug) { print "DEBUG: SSHCMD: $sshcmd\n"; }
 my ($sourcehost,$sourcefs,$sourceisroot) = getssh($rawsourcefs);
 my ($targethost,$targetfs,$targetisroot) = getssh($rawtargetfs);
@@ -111,14 +115,16 @@ if (!defined $args{'recursive'}) {
 	}
 }
 
-# close SSH sockets for master connections as applicable
-if ($sourcehost ne '') {
-	open FH, "$sshcmd $sourcehost -O exit 2>&1 |";
-	close FH;
-}
-if ($targethost ne '') {
-	open FH, "$sshcmd $targethost -O exit 2>&1 |";
-	close FH;
+if (!defined $args{'rsh'}) {
+  # close SSH sockets for master connections as applicable
+  if ($sourcehost ne '') {
+  	open FH, "$sshcmd $sourcehost -O exit 2>&1 |";
+  	close FH;
+  }
+  if ($targethost ne '') {
+  	open FH, "$sshcmd $targethost -O exit 2>&1 |";
+  	close FH;
+  }
 }
 
 exit 0;
@@ -823,11 +829,13 @@ sub getssh {
 		my $remoteuser = $rhost;
 		 $remoteuser =~ s/\@.*$//;
 		if ($remoteuser eq 'root') { $isroot = 1; } else { $isroot = 0; }
-		# now we need to establish a persistent master SSH connection
-		$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
-		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
-		close FH;
-		$rhost = "-S $socket $rhost";
+		if (!defined $args{'rsh'}) {
+		  # now we need to establish a persistent master SSH connection
+			$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
+			open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
+			close FH;
+			$rhost = "-S $socket $rhost";
+		}
 	} else {
 		my $localuid = $<;
 		if ($localuid == 0) { $isroot = 1; } else { $isroot = 0; }
@@ -984,3 +992,4 @@ Options:
   --dumpsnaps           Dumps a list of snapshots during the run
   --no-command-checks   Do not check command existence before attempting transfer. Not recommended
   --direct              Disable external compression, buffering, and progress view
+  --rsh									Use rsh instead of ssh (to avoid encryption overhead)


### PR DESCRIPTION
These are a series of commits intended to make initial synchronization of largeish datasets more efficient.  It also adds support for the recently-released send compressed mode (well, recently on Linux with zfsonlinux-0.7, I don't know about other zfs distributions).  In addition, a bug that (probably?) would result in use of undefined values when the --no-command-check option was resolved.

New options:
--compress=zfs adds "-c" to "zfs send", to enable sending compressed data without the need to decompress from the pool, compress for transfer, decompress on receive, then compress again when writing to the pool.
--direct bypasses mbuffer, pv, and external compression, and avoids checking these things.  My motivation was driven by the WARN messages emitted when these weren't found.  Since there is no way to disable those messages (i.e., --quiet doesn't silence them), and since they aren't needed in my use case, I figured an option to bypass them was suitable.
--rsh goes old-school and eliminates the ssh encryption overhead.  An ssh which permits -c none would be preferable, but isn't readily available (it's not available in vanilla ssh on RHEL, and installing alternate ssh packages seems icky).  Certainly using rsh isn't suitable in many cases, but it saves quite a bit of time transferring between two systems on the same switch.

These changes are fairly minimal and add some helpful functionality to my world.  Please advise if they are inadequate.