### PR TITLE
Zfs Recursion

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -503,12 +503,11 @@ sub take_snapshots {
 					%datestamp = get_date();
 					# print "we should have had a $type snapshot of $path $maxage seconds ago; most recent is $newestage seconds old.\n";
 
-					# use zfs recursion if specified in config
+					# use zfs (atomic) recursion if specified in config
 					if ($config{$section}{'zfs_recursion'}) {
-						push(@newsnaps, "-r $path\@autosnap_$datestamp{'sortable'}_$type");
-
-					}else{
-						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}_$type");
+						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type\@");
+					} else {
+						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type");
 					}
 				}
 			}
@@ -517,8 +516,14 @@ sub take_snapshots {
 
 	if ( (scalar(@newsnaps)) > 0) {
 		foreach my $snap ( @newsnaps ) {
-			my $dataset = (split '@', $snap)[0];
-			my $snapname = (split '@', $snap)[1];
+			my @split = split '@', $snap, -1;
+			my $recursiveFlag = 0;
+			if (scalar(@split) == 3) {
+				$recursiveFlag = 1;
+				chop $snap;
+			}
+			my $dataset = $split[0];
+			my $snapname = $split[1];
 			my $presnapshotfailure = 0;
 			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
 				$ENV{'SANOID_TARGET'} = $dataset;
@@ -537,8 +542,13 @@ sub take_snapshots {
 			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
-				system("$zfs snapshot $snap") == 0
-					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
+				if ($recursiveFlag) {
+					system($zfs, "snapshot", "-r", "$snap") == 0
+						or warn "CRITICAL ERROR: $zfs snapshot -r $snap failed, $?";
+				} else {
+					system($zfs, "snapshot", "$snap") == 0
+						or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
+				}
 			}
 			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
 				if (!$presnapshotfailure or $config{$dataset}{'force_post_snapshot_script'}) {
@@ -853,10 +863,9 @@ sub init {
 		my $recursive = $ini{$section}{'recursive'} && grep( /^$ini{$section}{'recursive'}$/, @istrue );
 		my $skipChildren = $ini{$section}{'skip_children'} && grep( /^$ini{$section}{'skip_children'}$/, @istrue );
 		my @datasets;
-
-		if($ini{$section}{'recursive'} =~ /zfs/i) {
+		if ($ini{$section}{'recursive'} =~ /zfs/i) {
 			$config{$section}{'zfs_recursion'} = 1;
-		}elsif ($ini{$section}{'recursive'}) {
+		} elsif ($recursive || $skipChildren) {
 			@datasets = getchilddatasets($config{$section}{'path'});
 			DATASETS: foreach my $dataset(@datasets) {
 				chomp $dataset;

--- a/sanoid
+++ b/sanoid
@@ -502,7 +502,14 @@ sub take_snapshots {
 					# update to most current possible datestamp
 					%datestamp = get_date();
 					# print "we should have had a $type snapshot of $path $maxage seconds ago; most recent is $newestage seconds old.\n";
-					push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type");
+
+					# use zfs recursion if specified in config
+					if ($config{$section}{'zfs_recursion'}) {
+						push(@newsnaps, "-r $path\@autosnap_$datestamp{'sortable'}_$type");
+
+					}else{
+						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}_$type");
+					}
 				}
 			}
 		}
@@ -530,7 +537,7 @@ sub take_snapshots {
 			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
-				system($zfs, "snapshot", "$snap") == 0
+				system("$zfs snapshot $snap") == 0
 					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
 			}
 			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
@@ -846,7 +853,10 @@ sub init {
 		my $recursive = $ini{$section}{'recursive'} && grep( /^$ini{$section}{'recursive'}$/, @istrue );
 		my $skipChildren = $ini{$section}{'skip_children'} && grep( /^$ini{$section}{'skip_children'}$/, @istrue );
 		my @datasets;
-		if ($recursive || $skipChildren) {
+
+		if($ini{$section}{'recursive'} =~ /zfs/i) {
+			$config{$section}{'zfs_recursion'} = 1;
+		}elsif ($ini{$section}{'recursive'}) {
 			@datasets = getchilddatasets($config{$section}{'path'});
 			DATASETS: foreach my $dataset(@datasets) {
 				chomp $dataset;


### PR DESCRIPTION
Allows the user in the config to specify to use zfs snapshot recursion option other than using Perl to recursively take snapshots. So your config would look like 
############################################
[pool4/zones/zone1]
        use_template = production
        recursive = zfs

[pool4/zones/zone2]
        use_template = production
        recursive = yes

zone1 would use use zfs recursion and zone2 would use Sanoid's way.
Zone1 recursive snapshot would look like: /sbin/zfs snapshot -r pool4/zones/zone1@autosnap_2017-12-19_15:37:21_hourly ....