### PR TITLE
Added "force-prune" option to skip busy dataset check

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -18,7 +18,7 @@ use Time::Local;      # to parse dates in reverse
 my %args = ("configdir" => "/etc/sanoid");
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
                    "monitor-health", "force-update", "configdir=s",
-                   "monitor-snapshots", "take-snapshots", "prune-snapshots"
+                   "monitor-snapshots", "take-snapshots", "prune-snapshots", "force-prune"
           ) or pod2usage(2);
 
 # If only config directory (or nothing) has been specified, default to --cron --verbose
@@ -234,7 +234,7 @@ sub prune_snapshots {
 						writelock('sanoid_pruning');
 						foreach my $snap( @prunesnaps ){
 							if ($args{'verbose'}) { print "INFO: pruning $snap ... \n"; }
-							if (iszfsbusy($path)) {
+							if (iszfsbusy($path) && !$args{'force-prune'}) {
 								print "INFO: deferring pruning of $snap - $path is currently in zfs send or receive.\n";
 							} else {
 								if (! $args{'readonly'}) { system($zfs, "destroy",$snap) == 0 or warn "could not remove $snap : $?"; }
@@ -1082,6 +1082,7 @@ Options:
   --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
   --take-snapshots      Creates snapshots as specified in sanoid.conf
   --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
+  --force-prune		Purges expired snapshots even if a send/recv is in progress
 
   --help                Prints this helptext
   --version             Prints the version number

--- a/syncoid
+++ b/syncoid
@@ -19,7 +19,7 @@ use Sys::Hostname;
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap") or pod2usage(2);
+                   "debug", "quiet", "no-stream", "no-sync-snap", "no-clone-rollback") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -306,13 +306,17 @@ sub syncdataset {
 			if (!$quiet) { print "INFO: no snapshots on source newer than $newsyncsnap on target. Nothing to do, not syncing.\n"; }
 		} else {
 			# rollback target to matchingsnap
+			my $rollbacktype="-R";
+			if (defined $args{'no-clone-rollback'}) {
+				$rollbacktype = "-r";
+			}
 			if ($debug) { print "DEBUG: rolling back target to $targetfs\@$matchingsnap...\n"; }
 			if ($targethost ne '') {
-				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap\n"; }
-				system ("$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap");
+				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback $rollbacktype $targetfs\@$matchingsnap\n"; }
+				system ("$sshcmd $targethost $targetsudocmd $zfscmd rollback $rollbacktype $targetfs\@$matchingsnap");
 			} else {
-				if ($debug) { print "$targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap\n"; }
-				system ("$targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap");
+				if ($debug) { print "$targetsudocmd $zfscmd rollback $rollbacktype $targetfs\@$matchingsnap\n"; }
+				system ("$targetsudocmd $zfscmd rollback $rollbacktype $targetfs\@$matchingsnap");
 			}
 
 			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefs\@$matchingsnap $sourcefs\@$newsyncsnap";
@@ -949,6 +953,7 @@ Options:
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer
   --no-stream           Replicates using newest snapshot instead of intermediates
   --no-sync-snap        Does not create new snapshot, only transfers existing
+  --no-clone-rollback	Does not rollback clones on target
 
   --sshkey=FILE         Specifies a ssh public key to use to connect
   --sshport=PORT        Connects to remote on a particular port


### PR DESCRIPTION
Each time `sanoid` wants to prune a snapshot (via `--cron` or `prune-snapshots` options) it check if a send/recv is in progress. This is a sensible default, as sending or receiving large dataset is an "heavy" operation which can be slowed by other dataset-level operation.

However, a problem arise when `syncoid` runs with very high frequency (ie: each minute or even less): as it is very likely the dataset is sending/receiving (albeit small changes), `sanoid` can not prune older snapshot, even snapshots which are very old (ie: days/months).

I propose a new `--force-prune` option, which basically skip the zfs busy check function (`iszfsbusy`) and go ahead with the pruning even if a send/recv is running. In case `sanoid` tries to delete a sending/receiving snapshot, the pruning will be blocked by ZFS itself, with an "dataset is busy" message.

**EXAMPLE (current behavior):**
*Result:* during a `syncoid` session, no snapshots are pruned (not even older, not-synching ones).
*Note:* I mangled the cache file to force a prune run.
```
[root@blackhole sanoid]# sed -i s/'hourly.*creation.*1515'/'hourly creation 0000'/ /var/cache/sanoidsnapshots.txt; ./sanoid --prune-snapshots --verbose; echo $?                                                   INFO: pruning snapshots...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:28_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:28_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:05:30_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:30_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:05:32_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:32_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:05:35_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:35_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:05:37_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:37_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:05:39_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:05:39_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:12:47_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:12:47_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:12:49_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:12:49_hourly - tank/test is currently in zfs send or receive.
INFO: pruning tank/test@autosnap_2018-01-04_12:12:51_hourly ...
INFO: deferring pruning of tank/test@autosnap_2018-01-04_12:12:51_hourly - tank/test is currently in zfs send or receive.
INFO: cache expired - updating from zfs list.
0
```


**EXAMPLE (patched behavior):**
*Result:* during a `syncoid` session, previous not-synching snapshots are pruned. Any eventual in-sync snapshot is retained/protected by ZFS itself.
*Note:* I mangled the cache file to force a prune run.
```
[root@blackhole sanoid]# sed -i s/'hourly.*creation.*1515'/'hourly creation 0000'/ /var/cache/sanoidsnapshots.txt; ./sanoid --prune-snapshots --verbose --force-prune; echo $?
INFO: pruning snapshots...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:28_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:30_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:32_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:35_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:37_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:05:39_hourly ...
INFO: pruning tank/test@autosnap_2018-01-04_12:12:47_hourly ...
cannot destroy snapshot tank/test@autosnap_2018-01-04_12:12:47_hourly: dataset is busy
could not remove tank/test@autosnap_2018-01-04_12:12:47_hourly : 256 at ./sanoid line 240.
INFO: pruning tank/test@autosnap_2018-01-04_12:12:49_hourly ...
cannot destroy snapshot tank/test@autosnap_2018-01-04_12:12:49_hourly: dataset is busy
could not remove tank/test@autosnap_2018-01-04_12:12:49_hourly : 256 at ./sanoid line 240.
INFO: pruning tank/test@autosnap_2018-01-04_12:12:51_hourly ...
cannot destroy snapshot tank/test@autosnap_2018-01-04_12:12:51_hourly: dataset is busy
could not remove tank/test@autosnap_2018-01-04_12:12:51_hourly : 256 at ./sanoid line 240.
INFO: pruning tank/test@autosnap_2018-01-04_12:13:11_hourly ...
INFO: cache expired - updating from zfs list.
0
```