### PR TITLE
added ability to skip datasets... simply set syncoid:no-sync=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,14 @@ If ZFS supports resumeable send/receive streams on both the source and target th
 
 As of 1.4.18, syncoid also automatically supports and enables resume of interrupted replication when both source and target support this feature.
 
+##### Syncoid Dataset Properties
+
++ syncoid:no-sync
+
+  Setting this to `true` will prevent the dataset from being handled by syncoid in _any_ way - it will be skipped. This can be useful for preventing certain datasets from being transferred when recursively handling a tree.
+
+  Note that this will also prevent syncoid from handling the dataset if given explicitly on the command line.
+
 ##### Syncoid Command Line Options
 
 + [source]

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
   _Note_: this will also prevent syncoid from handling the dataset if given explicitly on the command line.
 
-  _Note_: syncing a child of a no-sync dataset will currently result in a critical error
+  _Note_: syncing a child of a no-sync dataset will currently result in a critical error.
+
+  _Note_: empty properties will be handled as if they were unset.
 
 ##### Syncoid Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,27 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 ##### Syncoid Dataset Properties
 
-+ syncoid:no-sync
++ syncoid:sync
 
-  Setting this to `true` will prevent the dataset from being handled by syncoid in _any_ way - it will be skipped. This can be useful for preventing certain datasets from being transferred when recursively handling a tree.
+  Available values:
 
-  Note that this will also prevent syncoid from handling the dataset if given explicitly on the command line.
+  + `true` (default if unset)
+
+    This dataset will be synchronised to all hosts.
+
+  + `false`
+
+    This dataset will not be synchronised to any hosts - it will be skipped. This can be useful for preventing certain datasets from being transferred when recursively handling a tree.
+
+  + `host1,host2,...`
+
+    A comma seperated list of hosts. This dataset will only be synchronised by hosts listed in the property.
+
+    _Note_: this check is performed by the host running `syncoid`, thus the local hostname must be present for inclusion during a push operation // the remote hostname must be present for a pull.
+
+  _Note_: this will also prevent syncoid from handling the dataset if given explicitly on the command line.
+
+  _Note_: syncing a child of a no-sync dataset will currently result in a critical error
 
 ##### Syncoid Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
   + `host1,host2,...`
 
-    A comma seperated list of hosts. This dataset will only be synchronised by hosts listed in the property.
+    A comma separated list of hosts. This dataset will only be synchronised by hosts listed in the property.
 
     _Note_: this check is performed by the host running `syncoid`, thus the local hostname must be present for inclusion during a push operation // the remote hostname must be present for a pull.
 

--- a/syncoid
+++ b/syncoid
@@ -183,9 +183,20 @@ sub syncdataset {
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
-	if (getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync') eq 'false') {
+	my $sync = getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync');
+
+	if ($sync eq 'true' || $sync eq '-') {
+		# definitely sync this dataset - if a host is called 'true' or '-', then you're special
+	} elsif ($sync eq 'false') {
 		if (!$quiet) { print "INFO: Skipping dataset (syncoid:sync=false): $sourcefs...\n"; }
 		return 0;
+	} else {
+		my $hostid = hostname();
+		my @hosts = split(/,/,$sync);
+		if (!(grep $hostid eq $_, @hosts)) {
+			if (!$quiet) { print "INFO: Skipping dataset (syncoid:sync doesn't include $hostid): $sourcefs...\n"; }
+			return 0;
+		}
 	}
 
 	# make sure target is not currently in receive.

--- a/syncoid
+++ b/syncoid
@@ -185,7 +185,8 @@ sub syncdataset {
 
 	my $sync = getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync');
 
-	if ($sync eq 'true' || $sync eq '-') {
+	if ($sync eq 'true' || $sync eq '-' || $sync eq '') {
+		# empty is handled the same as unset (aka: '-')
 		# definitely sync this dataset - if a host is called 'true' or '-', then you're special
 	} elsif ($sync eq 'false') {
 		if (!$quiet) { print "INFO: Skipping dataset (syncoid:sync=false): $sourcefs...\n"; }

--- a/syncoid
+++ b/syncoid
@@ -183,8 +183,8 @@ sub syncdataset {
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
-	if (getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:no-sync') eq 'true') {
-		if (!$quiet) { print "INFO: Skipping dataset (syncoid:nosync=true): $sourcefs...\n"; }
+	if (getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync') eq 'false') {
+		if (!$quiet) { print "INFO: Skipping dataset (syncoid:sync=false): $sourcefs...\n"; }
 		return 0;
 	}
 

--- a/syncoid
+++ b/syncoid
@@ -184,7 +184,7 @@ sub syncdataset {
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
 	if (getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:no-sync') eq 'true') {
-		print "Skipping dataset (syncoid:nosync=true): $sourcefs...\n";
+		if (!$quiet) { print "INFO: Skipping dataset (syncoid:nosync=true): $sourcefs...\n"; }
 		return 0;
 	}
 

--- a/syncoid
+++ b/syncoid
@@ -183,6 +183,11 @@ sub syncdataset {
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
+	if (getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:no-sync') eq 'true') {
+		print "Skipping dataset (syncoid:nosync=true): $sourcefs...\n";
+		return 0;
+	}
+
 	# make sure target is not currently in receive.
 	if (iszfsbusy($targethost,$targetfs,$targetisroot)) {
 		warn "Cannot sync now: $targetfs is already target of a zfs receive process.\n";


### PR DESCRIPTION
I had a use case where I _do not_ wish to backup large / scratch datasets, but I _do_ wish to backup the tree that they are in.

To skip a dataset, set `syncoid:no-sync` to `true`:

```
zfs set syncoid:no-sync=true tank/users/attie/scratch
```

You can subsequently backup `tank/users` without including `tank/users/attie/scratch`.