### PR TITLE
Add pre and post snapshot scripts

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -455,12 +455,35 @@ sub take_snapshots {
 
 	if ( (scalar(@newsnaps)) > 0) {
 		foreach my $snap ( @newsnaps ) {
+			my $dataset = (split '@', $snap)[0];
+			my $presnapshotfailure = 0;
+			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
+				$ENV{'SANOID_TARGET'} = $dataset;
+				if ($args{'verbose'}) { print "executing pre_snapshot_script '".$config{$dataset}{'pre_snapshot_script'}."' on dataset '$dataset'\n"; }
+				if (system($config{$dataset}{'pre_snapshot_script'}) != 0) {
+					warn "WARN: pre_snapshot_script failed, $?";
+					$config{$dataset}{'no_inconsistent_snapshot'} and next;
+					$presnapshotfailure = 1;
+				}
+				delete $ENV{'SANOID_TARGET'};
+			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
 				system($zfs, "snapshot", "$snap") == 0
 					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
 				# make sure we don't end up with multiple snapshots with the same ctime
 				sleep 1;
+			}
+			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
+				if (!$presnapshotfailure or $config{$dataset}{'force_post_snapshot_script'}) {
+					$ENV{'SANOID_TARGET'} = $dataset;
+					if ($args{'verbose'}) { print "executing post_snapshot_script '".$config{$dataset}{'post_snapshot_script'}."' on dataset '$dataset'\n"; }
+					if (system($config{$dataset}{'post_snapshot_script'}) != 0) {
+						warn "WARN: post_snapshot_script failed, $?";
+						$config{$dataset}{'no_inconsistent_snapshot'} and next;
+					}
+					delete $ENV{'SANOID_TARGET'};
+				}
 			}
 		}
 		$forcecacheupdate = 1;
@@ -661,7 +684,7 @@ sub init {
 	tie my %ini, 'Config::IniFiles', ( -file => $conf_file ) or die "FATAL: cannot load $conf_file - please create a valid local config file before running sanoid!";
 
 	# we'll use these later to normalize potentially true and false values on any toggle keys
-	my @toggles = ('autosnap','autoprune','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only');
+	my @toggles = ('autosnap','autoprune','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only','no_inconsistent_snapshot','force_post_snapshot_script');
 	my @istrue=(1,"true","True","TRUE","yes","Yes","YES","on","On","ON");
 	my @isfalse=(0,"false","False","FALSE","no","No","NO","off","Off","OFF");
 

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -67,6 +67,17 @@
 	daily_warn = 48
 	daily_crit = 60
 
+[template_scripts]
+	### run script before snapshot
+	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	pre_snapshot_script = /path/to/script.sh
+	### run script after snapshot
+	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	post_snapshot_script = /path/to/script.sh
+	### don't take an inconsistent snapshot
+	#no_inconsistent_snapshot = yes
+	### run post_snapshot_script when pre_snapshot_script is failing
+	#force_post_snapshot_script = yes
 
 [template_ignore]
 	autoprune = no

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -15,6 +15,10 @@ path =
 recursive =
 use_template =
 process_children_only =
+pre_snapshot_script =
+post_snapshot_script =
+no_inconsistent_snapshot =
+force_post_snapshot_script =
 
 # If any snapshot type is set to 0, we will not take snapshots for it - and will immediately
 # prune any of those type snapshots already present.


### PR DESCRIPTION
Execute scripts before and after snapshot creation (#105).

Example with the following datasets:
```
# zfs list -o name -H
zfspool
zfspool/containers
zfspool/containers/dbserver
zfspool/containers/webserver
```
File `/etc/sanoid/sanoid.conf`:
```
[zfspool/containers]
	use_template = containers
	recursive = yes
	process_children_only = yes
	prescript = /opt/scripts/prescript.sh
	postscript = /opt/scripts/postscript.sh

[template_containers]
	autosnap = yes
	autoprune = yes
	hourly = 0
	daily = 30
	monthly = 0
	yearly = 0
```
Scripts:
```
# ls -l /opt/scripts/prescript.sh /opt/scripts/postscript.sh 
-rwxr--r-- 1 root root 113 Jan 13 12:56 /opt/scripts/postscript.sh
-rwxr--r-- 1 root root 113 Jan 13 12:56 /opt/scripts/prescript.sh
```
Script example:
```bash
#!/bin/bash
if [ $# != 1 ] ; then
    echo "Usage: $0 <snapshot>"
    exit 1
fi

SNAPSHOT=$1

# Do stuff
exit 0
```
Execution:
```
# ./sanoid --verbose --take-snapshots
INFO: cache expired - updating from zfs list.
INFO: taking snapshots...
executing prescript '/opt/scripts/prescript.sh zfspool/containers/dbserver@autosnap_2018-01-13_13:55:44_daily'
taking snapshot zfspool/containers/dbserver@autosnap_2018-01-13_13:55:44_daily
executing postscript '/opt/scripts/postscript.sh zfspool/containers/dbserver@autosnap_2018-01-13_13:55:44_daily'
executing prescript '/opt/scripts/prescript.sh zfspool/containers/webserver@autosnap_2018-01-13_13:55:44_daily'
taking snapshot zfspool/containers/webserver@autosnap_2018-01-13_13:55:44_daily
executing postscript '/opt/scripts/postscript.sh zfspool/containers/webserver@autosnap_2018-01-13_13:55:44_daily'
INFO: cache expired - updating from zfs list.
```
Snapshot created with pre and post scripts:
```
# zfs list -t all -o name -H
zfspool
zfspool/containers
zfspool/containers/dbserver
zfspool/containers/dbserver@autosnap_2018-01-13_13:55:44_daily
zfspool/containers/webserver
zfspool/containers/webserver@autosnap_2018-01-13_13:55:44_daily
```
It can be handy for some database services where service must be down before creating the snapshot to make it consistent.