### PR TITLE
Resumable replication of interrupted zfs send/receive

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -919,7 +919,7 @@ sub getssh {
 	if ($fs =~ /\@/) {
 		$rhost = $fs;
 		$fs =~ s/^\S*\@\S*://;
-		$rhost =~ s/:$fs$//;
+		$rhost =~ s/:\Q$fs\E$//;
 		my $remoteuser = $rhost;
 		 $remoteuser =~ s/\@.*$//;
 		if ($remoteuser eq 'root') { $isroot = 1; } else { $isroot = 0; }

--- a/syncoid
+++ b/syncoid
@@ -97,7 +97,7 @@ if (! $args{'recursive'}) {
 	if ($debug) { print "DEBUG: recursive sync of $sourcefs.\n"; }
 	my @datasets = getchilddatasets($sourcehost, $sourcefs, $sourceisroot);
 	foreach my $dataset(@datasets) {
-		$dataset =~ s/$sourcefs//;
+		$dataset =~ s/\Q$sourcefs\E//;
 		chomp $dataset;
 		my $childsourcefs = $sourcefs . $dataset;
 		my $childtargetfs = $targetfs . $dataset;
@@ -126,11 +126,16 @@ exit 0;
 sub getchilddatasets {
 	my ($rhost,$fs,$isroot,%snaps) = @_;
 	my $mysudocmd;
+	my $fsescaped = escapeshellparam($fs);
 
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
 
-	my $getchildrencmd = "$rhost $mysudocmd $zfscmd list -o name -t filesystem,volume -Hr $fs |";
+	my $getchildrencmd = "$rhost $mysudocmd $zfscmd list -o name -t filesystem,volume -Hr $fsescaped |";
 	if ($debug) { print "DEBUG: getting list of child datasets on $fs using $getchildrencmd...\n"; }
 	open FH, $getchildrencmd;
 	my @children = <FH>;
@@ -142,6 +147,9 @@ sub getchilddatasets {
 sub syncdataset {
 
 	my ($sourcehost, $sourcefs, $targethost, $targetfs) = @_;
+
+	my $sourcefsescaped = escapeshellparam($sourcefs);
+	my $targetfsescaped = escapeshellparam($targetfs);
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
@@ -209,8 +217,8 @@ sub syncdataset {
 		# if --no-stream is specified, our full needs to be the newest snapshot, not the oldest.
 		if (defined $args{'no-stream'}) { $oldestsnap = getnewestsnapshot(\%snaps); }
 
-		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefs\@$oldestsnap";
-		my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfs";
+		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefsescaped\@$oldestsnap";
+		my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
 
 		my $pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap",0,$sourceisroot);
 		my $disp_pvsize = readablebytes($pvsize);
@@ -245,7 +253,7 @@ sub syncdataset {
 			# $originaltargetreadonly = getzfsvalue($targethost,$targetfs,$targetisroot,'readonly');
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly','on');
 
-			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefs\@$oldestsnap $sourcefs\@$newsyncsnap";
+			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnap $sourcefsescaped\@$newsyncsnap";
 			$pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			$disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -305,15 +313,15 @@ sub syncdataset {
 			# rollback target to matchingsnap
 			if ($debug) { print "DEBUG: rolling back target to $targetfs\@$matchingsnap...\n"; }
 			if ($targethost ne '') {
-				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap\n"; }
-				system ("$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap");
+				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap\n"; }
+				system ("$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap"));
 			} else {
-				if ($debug) { print "$targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap\n"; }
-				system ("$targetsudocmd $zfscmd rollback -R $targetfs\@$matchingsnap");
+				if ($debug) { print "$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap\n"; }
+				system ("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap");
 			}
 
-			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefs\@$matchingsnap $sourcefs\@$newsyncsnap";
-			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfs";
+			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnap $sourcefsescaped\@$newsyncsnap";
+			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -590,7 +598,7 @@ sub iszfsbusy {
 
 	foreach my $process (@processes) {
 		# if ($debug) { print "DEBUG: checking process $process...\n"; }
-		if ($process =~ /zfs *(receive|recv).*$fs/) {
+		if ($process =~ /zfs *(receive|recv).*\Q$fs\E/) {
 			# there's already a zfs receive process for our target filesystem - return true
 			if ($debug) { print "DEBUG: process $process matches target $fs!\n"; }
 			return 1;
@@ -603,24 +611,40 @@ sub iszfsbusy {
 
 sub setzfsvalue {
 	my ($rhost,$fs,$isroot,$property,$value) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+
+	my $fsescaped = escapeshellparam($fs);
+
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
+
 	if ($debug) { print "DEBUG: setting $property to $value on $fs...\n"; }
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	if ($debug) { print "$rhost $mysudocmd $zfscmd set $property=$value $fs\n"; }
-	system("$rhost $mysudocmd $zfscmd set $property=$value $fs") == 0
-		or warn "WARNING: $rhost $mysudocmd $zfscmd set $property=$value $fs died: $?, proceeding anyway.\n";
+	if ($debug) { print "$rhost $mysudocmd $zfscmd set $property=$value $fsescaped\n"; }
+	system("$rhost $mysudocmd $zfscmd set $property=$value $fsescaped") == 0
+		or warn "WARNING: $rhost $mysudocmd $zfscmd set $property=$value $fsescaped died: $?, proceeding anyway.\n";
 	return;
 }
 
 sub getzfsvalue {
 	my ($rhost,$fs,$isroot,$property) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+
+	my $fsescaped = escapeshellparam($fs);
+
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
+
 	if ($debug) { print "DEBUG: getting current value of $property on $fs...\n"; }
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	if ($debug) { print "$rhost $mysudocmd $zfscmd get -H $property $fs\n"; }
-	open FH, "$rhost $mysudocmd $zfscmd get -H $property $fs |";
+	if ($debug) { print "$rhost $mysudocmd $zfscmd get -H $property $fsescaped\n"; }
+	open FH, "$rhost $mysudocmd $zfscmd get -H $property $fsescaped |";
 	my $value = <FH>;
 	close FH;
 	my @values = split(/\s/,$value);
@@ -706,17 +730,24 @@ sub buildsynccmd {
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= " $pvcmd -s $pvsize |"; }
 		if ($avail{'compress'}) { $synccmd .= " $args{'compresscmd'} |"; }
 		if ($avail{'sourcembuffer'}) { $synccmd .= " $mbuffercmd $args{'source-bwlimit'} $mbufferoptions |"; }
-		$synccmd .= " $sshcmd $targethost '";
-		if ($avail{'targetmbuffer'}) { $synccmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
-		if ($avail{'compress'}) { $synccmd .= " $args{'decompresscmd'} |"; }
-		$synccmd .= " $recvcmd'";
+		$synccmd .= " $sshcmd $targethost ";
+
+		my $remotecmd = "";
+		if ($avail{'targetmbuffer'}) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
+		if ($avail{'compress'}) { $remotecmd .= " $args{'decompresscmd'} |"; }
+		$remotecmd .= " $recvcmd";
+
+		$synccmd .= escapeshellparam($remotecmd);
 	} elsif ($targethost eq '') {
 		# remote source, local target.
 		#$synccmd = "$sshcmd $sourcehost '$sendcmd | $args{'compresscmd'} | $mbuffercmd' | $args{'decompresscmd'} | $mbuffercmd | $pvcmd | $recvcmd";
-		$synccmd = "$sshcmd $sourcehost '$sendcmd";
-		if ($avail{'compress'}) { $synccmd .= " | $args{'compresscmd'}"; }
-		if ($avail{'sourcembuffer'}) { $synccmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
-		$synccmd .= "' | ";
+
+		my $remotecmd = $sendcmd;
+		if ($avail{'compress'}) { $remotecmd .= " | $args{'compresscmd'}"; }
+		if ($avail{'sourcembuffer'}) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
+
+		$synccmd = "$sshcmd $sourcehost " . escapeshellparam($remotecmd);
+		$synccmd .= " | ";
 		if ($avail{'targetmbuffer'}) { $synccmd .= "$mbuffercmd $args{'target-bwlimit'} $mbufferoptions | "; }
 		if ($avail{'compress'}) { $synccmd .= "$args{'decompresscmd'} | "; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= "$pvcmd -s $pvsize | "; }
@@ -724,25 +755,37 @@ sub buildsynccmd {
 	} else {
 		#remote source, remote target... weird, but whatever, I'm not here to judge you.
 		#$synccmd = "$sshcmd $sourcehost '$sendcmd | $args{'compresscmd'} | $mbuffercmd' | $args{'decompresscmd'} | $pvcmd | $args{'compresscmd'} | $mbuffercmd | $sshcmd $targethost '$args{'decompresscmd'} | $mbuffercmd | $recvcmd'";
-		$synccmd = "$sshcmd $sourcehost '$sendcmd";
-		if ($avail{'compress'}) { $synccmd .= " | $args{'compresscmd'}"; }
-		if ($avail{'sourcembuffer'}) { $synccmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
-		$synccmd .= "' | ";
+
+		my $remotecmd = $sendcmd;
+		if ($avail{'compress'}) { $remotecmd .= " | $args{'compresscmd'}"; }
+		if ($avail{'sourcembuffer'}) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
+
+		$synccmd = "$sshcmd $sourcehost " . escapeshellparam($remotecmd);
+		$synccmd .= " | ";
+
 		if ($avail{'compress'}) { $synccmd .= "$args{'decompresscmd'} | "; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= "$pvcmd -s $pvsize | "; }
 		if ($avail{'compress'}) { $synccmd .= "$args{'compresscmd'} | "; }
 		if ($avail{'localmbuffer'}) { $synccmd .= "$mbuffercmd $mbufferoptions | "; }
-		$synccmd .= "$sshcmd $targethost '";
-		if ($avail{'targetmbuffer'}) { $synccmd .= "$mbuffercmd $args{'target-bwlimit'} $mbufferoptions | "; }
-		if ($avail{'compress'}) { $synccmd .= "$args{'decompresscmd'} | "; }
-		$synccmd .= "$recvcmd'";
+		$synccmd .= "$sshcmd $targethost ";
+
+		$remotecmd = "";
+		if ($avail{'targetmbuffer'}) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
+		if ($avail{'compress'}) { $remotecmd .= " $args{'decompresscmd'} |"; }
+		$remotecmd .= " $recvcmd";
+
+		$synccmd .= escapeshellparam($remotecmd);
 	}
 	return $synccmd;
 }
 
 sub pruneoldsyncsnaps {
 	my ($rhost,$fs,$newsyncsnap,$isroot,@snaps) = @_;
+
+	my $fsescaped = escapeshellparam($fs);
+
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+
 	my $hostid = hostname();
 
 	my $mysudocmd;
@@ -752,7 +795,7 @@ sub pruneoldsyncsnaps {
 
 	# only prune snaps beginning with syncoid and our own hostname
 	foreach my $snap(@snaps) {
-		if ($snap =~ /^syncoid_$hostid/) {
+		if ($snap =~ /^syncoid_\Q$hostid\E/) {
 			# no matter what, we categorically refuse to
 			# prune the new sync snap we created for this run
 			if ($snap ne $newsyncsnap) {
@@ -768,12 +811,14 @@ sub pruneoldsyncsnaps {
 	my $prunecmd;
 	foreach my $snap(@prunesnaps) {
 		$counter ++;
-		$prunecmd .= "$mysudocmd $zfscmd destroy $fs\@$snap; ";
+		$prunecmd .= "$mysudocmd $zfscmd destroy $fsescaped\@$snap; ";
 		if ($counter > $maxsnapspercmd) {
 			$prunecmd =~ s/\; $//;
-			if ($rhost ne '') { $prunecmd = '"' . $prunecmd . '"'; }
 			if ($debug) { print "DEBUG: pruning up to $maxsnapspercmd obsolete sync snapshots...\n"; }
 			if ($debug) { print "DEBUG: $rhost $prunecmd\n"; }
+			if ($rhost ne '') {
+				$prunecmd = escapeshellparam($prunecmd);
+			}
 			system("$rhost $prunecmd") == 0
 				or warn "CRITICAL ERROR: $rhost $prunecmd failed: $?";
 			$prunecmd = '';
@@ -784,9 +829,11 @@ sub pruneoldsyncsnaps {
 	# the loop, commit 'em now
 	if ($counter) {
 		$prunecmd =~ s/\; $//;
-		if ($rhost ne '') { $prunecmd = '"' . $prunecmd . '"'; }
 		if ($debug) { print "DEBUG: pruning up to $maxsnapspercmd obsolete sync snapshots...\n"; }
 		if ($debug) { print "DEBUG: $rhost $prunecmd\n"; }
+		if ($rhost ne '') {
+			$prunecmd = escapeshellparam($prunecmd);
+		}
 		system("$rhost $prunecmd") == 0
 			or warn "WARNING: $rhost $prunecmd failed: $?";
 	}
@@ -824,13 +871,18 @@ sub getmatchingsnapshot {
 
 sub newsyncsnap {
 	my ($rhost,$fs,$isroot) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+	my $fsescaped = escapeshellparam($fs);
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 	my $hostid = hostname();
 	my %date = getdate();
 	my $snapname = "syncoid\_$hostid\_$date{'stamp'}";
-	my $snapcmd = "$rhost $mysudocmd $zfscmd snapshot $fs\@$snapname\n";
+	my $snapcmd = "$rhost $mysudocmd $zfscmd snapshot $fsescaped\@$snapname\n";
 	system($snapcmd) == 0
 		or die "CRITICAL ERROR: $snapcmd failed: $?";
 	return $snapname;
@@ -838,16 +890,21 @@ sub newsyncsnap {
 
 sub targetexists {
 	my ($rhost,$fs,$isroot) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+	my $fsescaped = escapeshellparam($fs);
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	my $checktargetcmd = "$rhost $mysudocmd $zfscmd get -H name $fs";
+	my $checktargetcmd = "$rhost $mysudocmd $zfscmd get -H name $fsescaped";
 	if ($debug) { print "DEBUG: checking to see if target filesystem exists using \"$checktargetcmd 2>&1 |\"...\n"; }
 	open FH, "$checktargetcmd 2>&1 |";
 	my $targetexists = <FH>;
 	close FH;
 	my $exit = $?;
-	$targetexists = ( $targetexists =~ /^$fs/ && $exit == 0 );
+	$targetexists = ( $targetexists =~ /^\Q$fs\E/ && $exit == 0 );
 	return $targetexists;
 }
 
@@ -888,11 +945,16 @@ sub dumphash() {
 sub getsnaps() {
 	my ($type,$rhost,$fs,$isroot,%snaps) = @_;
 	my $mysudocmd;
+	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		# double escaping needed
+		$fsescaped = escapeshellparam($fsescaped);
+	}
 
-	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t snapshot guid,creation $fs |";
+	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t snapshot guid,creation $fsescaped |";
 	if ($debug) { print "DEBUG: getting list of snapshots on $fs using $getsnapcmd...\n"; }
 	open FH, $getsnapcmd;
 	my @rawsnaps = <FH>;
@@ -903,24 +965,24 @@ sub getsnaps() {
 
 	foreach my $line (@rawsnaps) {
 		# only import snap guids from the specified filesystem
-		if ($line =~ /$fs\@.*guid/) {
+		if ($line =~ /\Q$fs\E\@.*guid/) {
 			chomp $line;
 			my $guid = $line;
 			$guid =~ s/^.*\sguid\s*(\d*).*/$1/;
 			my $snap = $line;
-			$snap =~ s/^\S*\@(\S*)\s*guid.*$/$1/;
+			$snap =~ s/^.*\@(\S*)\s*guid.*$/$1/;
 			$snaps{$type}{$snap}{'guid'}=$guid;
 		}
 	}
 
 	foreach my $line (@rawsnaps) {
 		# only import snap creations from the specified filesystem
-		if ($line =~ /$fs\@.*creation/) {
+		if ($line =~ /\Q$fs\E\@.*creation/) {
 			chomp $line;
 			my $creation = $line;
 			$creation =~ s/^.*\screation\s*(\d*).*/$1/;
 			my $snap = $line;
-			$snap =~ s/^\S*\@(\S*)\s*creation.*$/$1/;
+			$snap =~ s/^.*\@(\S*)\s*creation.*$/$1/;
 			$snaps{$type}{$snap}{'creation'}=$creation;
 		}
 	}
@@ -932,20 +994,29 @@ sub getsnaps() {
 sub getsendsize {
 	my ($sourcehost,$snap1,$snap2,$isroot) = @_;
 
+	my $snap1escaped = escapeshellparam($snap1);
+	my $snap2escaped = escapeshellparam($snap2);
+
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
+
+	my $sourcessh;
+	if ($sourcehost ne '') {
+		$sourcessh = "$sshcmd $sourcehost";
+		$snap1escaped = escapeshellparam($snap1escaped);
+		$snap2escaped = escapeshellparam($snap2escaped);
+	} else {
+		$sourcessh = '';
+	}
 
 	my $snaps;
 	if ($snap2) {
 		# if we got a $snap2 argument, we want an incremental send estimate from $snap1 to $snap2.
-		$snaps = "$args{'streamarg'} $snap1 $snap2";
+		$snaps = "$args{'streamarg'} $snap1escaped $snap2escaped";
 	} else {
 		# if we didn't get a $snap2 arg, we want a full send estimate for $snap1.
-		$snaps = "$snap1";
+		$snaps = "$snap1escaped";
 	}
-
-	my $sourcessh;
-	if ($sourcehost ne '') { $sourcessh = "$sshcmd $sourcehost"; } else { $sourcessh = ''; }
 
 	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send -nP $snaps";
 	if ($debug) { print "DEBUG: getting estimated transfer size from source $sourcehost using \"$getsendsizecmd 2>&1 |\"...\n"; }
@@ -987,3 +1058,11 @@ sub getdate {
 	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}:$date{'hour'}:$date{'min'}:$date{'sec'}";
 	return %date;
 }
+
+sub escapeshellparam {
+	my ($par) = @_;
+	# "escape" all single quotes
+	$par =~ s/'/'"'"'/g;
+	# single-quote entire string
+	return "'$par'";
+ }

--- a/syncoid
+++ b/syncoid
@@ -216,8 +216,9 @@ sub syncdataset {
 
 		# if --no-stream is specified, our full needs to be the newest snapshot, not the oldest.
 		if (defined $args{'no-stream'}) { $oldestsnap = getnewestsnapshot(\%snaps); }
+		my $oldestsnapescaped = escapeshellparam($oldestsnap);
 
-		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefsescaped\@$oldestsnap";
+		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefsescaped\@$oldestsnapescaped";
 		my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
 
 		my $pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap",0,$sourceisroot);
@@ -253,7 +254,7 @@ sub syncdataset {
 			# $originaltargetreadonly = getzfsvalue($targethost,$targetfs,$targetisroot,'readonly');
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly','on');
 
-			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnap $sourcefsescaped\@$newsyncsnap";
+			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnapescaped $sourcefsescaped\@$newsyncsnap";
 			$pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			$disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -310,17 +311,18 @@ sub syncdataset {
 			# barf some text but don't touch the filesystem
 			if (!$quiet) { print "INFO: no snapshots on source newer than $newsyncsnap on target. Nothing to do, not syncing.\n"; }
 		} else {
+			my $matchingsnapescaped = escapeshellparam($matchingsnap);
 			# rollback target to matchingsnap
 			if ($debug) { print "DEBUG: rolling back target to $targetfs\@$matchingsnap...\n"; }
 			if ($targethost ne '') {
-				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap\n"; }
-				system ("$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap"));
+				if ($debug) { print "$sshcmd $targethost $targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped\n"; }
+				system ("$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped"));
 			} else {
-				if ($debug) { print "$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap\n"; }
-				system ("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnap");
+				if ($debug) { print "$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped\n"; }
+				system ("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped");
 			}
 
-			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnap $sourcefsescaped\@$newsyncsnap";
+			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnap";
 			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);

--- a/syncoid
+++ b/syncoid
@@ -19,7 +19,7 @@ use Sys::Hostname;
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap") or pod2usage(2);
+                   "debug", "quiet", "no-stream", "no-sync-snap", "resume") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -161,34 +161,54 @@ sub syncdataset {
 	# does the target filesystem exist yet?
 	my $targetexists = targetexists($targethost,$targetfs,$targetisroot);
 
-	# build hashes of the snaps on the source and target filesystems.
+	my $receiveextraargs = "";
+	my $receivetoken;
+	if (defined $args{'resume'}) {
+		# save state of interrupted receive stream
+		$receiveextraargs = "-s";
 
-	%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
+		if ($targetexists) {
+			# check remote dataset for receive resume token (interrupted receive)
+			$receivetoken = getreceivetoken($targethost,$targetfs,$targetisroot);
 
-	if ($targetexists) {
-		my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
-		my %sourcesnaps = %snaps;
-		%snaps = (%sourcesnaps, %targetsnaps);
-	}
-
-	if (defined $args{'dumpsnaps'}) {
-		print "merged snapshot list of $targetfs: \n";
-		dumphash(\%snaps);
-		print "\n\n\n";
-	}
-
-	# create a new syncoid snapshot on the source filesystem.
-	my $newsyncsnap;
-	if (!defined $args{'no-sync-snap'}) {
-		$newsyncsnap = newsyncsnap($sourcehost,$sourcefs,$sourceisroot);
-	} else {
-		# we don't want sync snapshots created, so use the newest snapshot we can find.
-		$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
-		if ($newsyncsnap eq 0) {
-			warn "CRITICAL: no snapshots exist on source $sourcefs, and you asked for --no-sync-snap.\n";
-			return 0;
+			if ($debug && defined($receivetoken)) {
+				print "DEBUG: got receive resume token: $receivetoken: \n";
+			}
 		}
 	}
+
+	my $newsyncsnap;
+
+    # skip snapshot checking/creation in case of resumed receive
+    if (!defined($receivetoken)) {
+        # build hashes of the snaps on the source and target filesystems.
+
+        %snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
+
+        if ($targetexists) {
+            my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
+            my %sourcesnaps = %snaps;
+            %snaps = (%sourcesnaps, %targetsnaps);
+        }
+
+        if (defined $args{'dumpsnaps'}) {
+            print "merged snapshot list of $targetfs: \n";
+            dumphash(\%snaps);
+            print "\n\n\n";
+        }
+
+		if (!defined $args{'no-sync-snap'}) {
+			# create a new syncoid snapshot on the source filesystem.
+			$newsyncsnap = newsyncsnap($sourcehost,$sourcefs,$sourceisroot);
+		} else {
+			# we don't want sync snapshots created, so use the newest snapshot we can find.
+			$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
+			if ($newsyncsnap eq 0) {
+				warn "CRITICAL: no snapshots exist on source $sourcefs, and you asked for --no-sync-snap.\n";
+				return 0;
+			}
+		}
+    }
 
 	# there is currently (2014-09-01) a bug in ZFS on Linux
 	# that causes readonly to always show on if it's EVER
@@ -222,7 +242,7 @@ sub syncdataset {
 		my $oldestsnapescaped = escapeshellparam($oldestsnap);
 
 		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefsescaped\@$oldestsnapescaped";
-		my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
+		my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
 
 		my $pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap",0,$sourceisroot);
 		my $disp_pvsize = readablebytes($pvsize);
@@ -286,6 +306,27 @@ sub syncdataset {
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly',$originaltargetreadonly);
 		}
 	} else {
+        # resume interrupted receive if there is a valid resume $token
+        # and because this will ony resume the receive to the next
+        # snapshot, do a normal sync after that
+        if (defined($receivetoken)) {
+            my $sendcmd = "$sourcesudocmd $zfscmd send -t $receivetoken";
+            my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
+            my $pvsize = getsendsize($sourcehost,"","",$sourceisroot,$receivetoken);
+            my $disp_pvsize = readablebytes($pvsize);
+            if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
+            my $synccmd = buildsynccmd($sendcmd,$recvcmd,$pvsize,$sourceisroot,$targetisroot);
+
+            if (!$quiet) { print "Resuming interrupted zfs send/receive from $sourcefs to $targetfs (~ $disp_pvsize remaining):\n"; }
+            if ($debug) { print "DEBUG: $synccmd\n"; }
+            system("$synccmd") == 0
+                or die "CRITICAL ERROR: $synccmd failed: $?";
+
+            # a resumed transfer will only be done to the next snapshot,
+            # so do an normal sync cycle
+            return syncdataset($sourcehost, $sourcefs, $targethost, $targetfs);
+        }
+
 		# find most recent matching snapshot and do an -I
 		# to the new snapshot
 
@@ -326,7 +367,7 @@ sub syncdataset {
 			}
 
 			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnap";
-			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
+			my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -931,7 +972,7 @@ sub getsnaps() {
 
 
 sub getsendsize {
-	my ($sourcehost,$snap1,$snap2,$isroot) = @_;
+	my ($sourcehost,$snap1,$snap2,$isroot,$receivetoken) = @_;
 
 	my $snap1escaped = escapeshellparam($snap1);
 	my $snap2escaped = escapeshellparam($snap2);
@@ -957,6 +998,12 @@ sub getsendsize {
 		$snaps = "$snap1escaped";
 	}
 
+	# in case of a resumed receive, get the remaining
+	# size based on the resume token
+	if (defined($receivetoken)) {
+		$snaps = "-t $receivetoken";
+	}
+
 	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send -nP $snaps";
 	if ($debug) { print "DEBUG: getting estimated transfer size from source $sourcehost using \"$getsendsizecmd 2>&1 |\"...\n"; }
 
@@ -969,7 +1016,13 @@ sub getsendsize {
 	# size of proposed xfer in bytes, but we need to remove
 	# human-readable crap from it
 	my $sendsize = pop(@rawsize);
-	$sendsize =~ s/^size\s*//;
+	# the output format is different in case of
+	# a resumed receive
+	if (defined($receivetoken)) {
+		$sendsize =~ s/.*\s([0-9]+)$/$1/;
+	} else {
+		$sendsize =~ s/^size\s*//;
+	}
 	chomp $sendsize;
 
 	# to avoid confusion with a zero size pv, give sendsize
@@ -1004,6 +1057,21 @@ sub escapeshellparam {
 	$par =~ s/'/'"'"'/g;
 	# single-quote entire string
 	return "'$par'";
+}
+
+sub getreceivetoken() {
+	my ($rhost,$fs,$isroot) = @_;
+	my $token = getzfsvalue($rhost,$fs,$isroot,"receive_resume_token");
+
+	if ($token ne '-' && $token ne '') {
+		return $token;
+	}
+
+	if ($debug) {
+        print "DEBUG: no receive token found \n";
+    }
+
+	return
 }
 
 __END__
@@ -1043,3 +1111,4 @@ Options:
   --quiet               Suppresses non-error output
   --dumpsnaps           Dumps a list of snapshots during the run
   --no-command-checks   Do not check command existence before attempting transfer. Not recommended
+  --resume              Save the state of unfinished receive streams and resume interrupted ones if available

--- a/syncoid
+++ b/syncoid
@@ -1005,3 +1005,41 @@ sub escapeshellparam {
 	# single-quote entire string
 	return "'$par'";
 }
+
+__END__
+
+=head1 NAME
+
+syncoid - ZFS snapshot replication tool
+
+=head1 SYNOPSIS
+
+ syncoid [options]... SOURCE TARGET
+ or   syncoid [options]... SOURCE [USER@]HOST:TARGET
+ or   syncoid [options]... [USER@]HOST:SOURCE [TARGET]
+ or   syncoid [options]... [USER@]HOST:SOURCE [USER@]HOST:TARGET
+
+ SOURCE                Source ZFS dataset. Can be either local or remote
+ TARGET                Target ZFS dataset. Can be either local or remote
+
+Options:
+
+  --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, lzo (default) & none
+  --recursive|r         Also transfers child datasets
+  --source-bwlimit=<limit k|m|g|t>  Bandwidth limit on the source transfer
+  --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer
+  --no-stream           Replicates using newest snapshot instead of intermediates
+  --no-sync-snap        Does not create new snapshot, only transfers existing
+
+  --sshkey=FILE         Specifies a ssh public key to use to connect
+  --sshport=PORT        Connects to remote on a particular port
+  --sshcipher|c=CIPHER  Passes CIPHER to ssh to use a particular cipher set
+  --sshoption|o=OPTION  Passes OPTION to ssh for remote usage. Can be specified multiple times
+
+  --help                Prints this helptext
+  --verbose             Prints the version number
+  --debug               Prints out a lot of additional information during a syncoid run
+  --monitor-version     Currently does nothing
+  --quiet               Suppresses non-error output
+  --dumpsnaps           Dumps a list of snapshots during the run
+  --no-command-checks   Do not check command existence before attempting transfer. Not recommended


### PR DESCRIPTION
ZFS on Linux supports resume able zfs send/receive (since v0.7; and probably other zfs implementations too) in case the process is interrupted somehow (timeout, ...). This PR adds support for syncoid utilizing this awesome zfs feature if requested by the user via a comand line flag "--resume":

- for each dataset the target is checked for a receive_resume_token
- if one is found the zfs send/receive is resumed
- after this is finished successfully a ordinary sync is done, because the resumed zfs send will only be done to the next snapshot
- all the zfs receives will be instructed to save the state instead of discarding it in the case the resume flag is set (-s)
- if the feature is not supported by the target host, syncoid errors out

My primary use case is for initial and big incremental backup streams, i eventually want to switch my rsync based remote backups over to zfs send/receive. But for my private and also work uplinks it is almost sure the won't work through the whole initial zfs send/receive which probably take several weeks.