### PR TITLE
implemented monitor-capacity flag for checking zpool capacity limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 	This option is designed to be run by a Nagios monitoring system. It reports on the health of the zpool your filesystems are on. It only monitors filesystems that are configured in the sanoid.conf file.
 
++ --monitor-capacity
+
+	This option is designed to be run by a Nagios monitoring system. It reports on the capacity of the zpool your filesystems are on. It only monitors pools that are configured in the sanoid.conf file. The default limits are 80% for the warning and 95% for the critical state. Those can be overridden by providing them
+	along like '=80,95". 
+
 + --force-update
 
 	This clears out sanoid's zfs snapshot listing cache. This is normally not needed.

--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 + --monitor-capacity
 
-	This option is designed to be run by a Nagios monitoring system. It reports on the capacity of the zpool your filesystems are on. It only monitors pools that are configured in the sanoid.conf file. The default limits are 80% for the warning and 95% for the critical state. Those can be overridden by providing them
-	along like '=80,95". 
+	This option is designed to be run by a Nagios monitoring system. It reports on the capacity of the zpool your filesystems are on. It only monitors pools that are configured in the sanoid.conf file.
 
 + --force-update
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 + --monitor-health
 
-	This option is designed to be run by a Nagios monitoring system. It reports on the health of the zpool your filesystems are on. It only monitors filesystems that are configured in the sanoid.conf file. Optionally it can check capacity limits too by appending them like '=80,95" (>= 80% warning, >=95% critical).
+	This option is designed to be run by a Nagios monitoring system. It reports on the health of the zpool your filesystems are on. It only monitors filesystems that are configured in the sanoid.conf file.
 
 + --force-update
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 + --monitor-health
 
-	This option is designed to be run by a Nagios monitoring system. It reports on the health of the zpool your filesystems are on. It only monitors filesystems that are configured in the sanoid.conf file.
+	This option is designed to be run by a Nagios monitoring system. It reports on the health of the zpool your filesystems are on. It only monitors filesystems that are configured in the sanoid.conf file. Optionally it can check capacity limits too by appending them like '=80,95" (>= 80% warning, >=95% critical).
 
 + --force-update
 

--- a/sanoid
+++ b/sanoid
@@ -798,17 +798,6 @@ sub check_zpool() {
 	## determine health of zpool and subsequent error status
 	if ($health eq "ONLINE" ) {
 		$state = "OK";
-
-		# check capacity
-		my $capn = $cap;
-		$capn =~ s/\D//g;
-
-		if ($capn >= 80) {
-			$state = "WARNING";
-		}
-		if ($capn >= 95) {
-			$state = "CRITICAL";
-		}
 	} else {
 		if ($health eq "DEGRADED") {
 			$state = "WARNING";

--- a/sanoid
+++ b/sanoid
@@ -17,7 +17,7 @@ use Time::Local;      # to parse dates in reverse
 
 my %args = ("configdir" => "/etc/sanoid");
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
-                   "monitor-health:s", "force-update", "configdir=s",
+                   "monitor-health", "force-update", "configdir=s",
                    "monitor-snapshots", "take-snapshots", "prune-snapshots"
           ) or pod2usage(2);
 
@@ -51,7 +51,7 @@ my @params = ( \%config, \%snaps, \%snapsbytype, \%snapsbypath );
 
 if ($args{'debug'})		{ $args{'verbose'}=1; blabber (@params); }
 if ($args{'monitor-snapshots'}) { monitor_snapshots(@params); }
-if (defined($args{'monitor-health'})) 	{ monitor_health(@params); }
+if ($args{'monitor-health'}) 	{ monitor_health(@params); }
 if ($args{'force-update'}) 	{ my $snaps = getsnaps( \%config, $cacheTTL, 1 ); }
 
 if ($args{'cron'}) {
@@ -76,32 +76,13 @@ sub monitor_health {
 	my @messages;
 	my $errlevel=0;
 
-	my %capacitylimits;
-
-	# if provided, parse capacity limits
-	if ($args{'monitor-health'} ne "") {
-		my @values = split(',', $args{'monitor-health'});
-
-		if (!check_capacity_limit($values[0])) {
-			die "ERROR: invalid zpool capacity warning limit!\n";
-		}
-		$capacitylimits{"warn"} = $values[0];
-
-		if (scalar @values > 1) {
-			if (!check_capacity_limit($values[1])) {
-				die "ERROR: invalid zpool capacity critical limit!\n";
-			}
-			$capacitylimits{"crit"} = $values[1];
-		}
-	}
-
 	foreach my $path (keys %{ $snapsbypath}) {
 		my @pool = split ('/',$path);
 		$pools{$pool[0]}=1;
 	}
 
 	foreach my $pool (keys %pools) {
-		my ($exitcode, $msg) = check_zpool($pool,2,\%capacitylimits);
+		my ($exitcode, $msg) = check_zpool($pool,2);
 		if ($exitcode > $errlevel) { $errlevel = $exitcode; }
 		chomp $msg;
 		push (@messages, $msg);
@@ -767,8 +748,6 @@ sub check_zpool() {
 
 	my $pool=shift;
 	my $verbose=shift;
-	my $capacitylimitsref=shift;
-	my %capacitylimits=%$capacitylimitsref;
 
 	my $size="";
 	my $used="";
@@ -820,21 +799,15 @@ sub check_zpool() {
 	if ($health eq "ONLINE" ) {
 		$state = "OK";
 
-		if (%capacitylimits) {
-			# check capacity
-			my $capn = $cap;
-			$capn =~ s/\D//g;
+		# check capacity
+		my $capn = $cap;
+		$capn =~ s/\D//g;
 
-			if ($capacitylimits{"warn"}) {
-				if ($capn >= $capacitylimits{"warn"}) {
-					$state = "WARNING";
-				}
-			}
-			if ($capacitylimits{"crit"}) {
-				if ($capn >= $capacitylimits{"crit"}) {
-					$state = "CRITICAL";
-				}
-			}
+		if ($capn >= 80) {
+			$state = "WARNING";
+		}
+		if ($capn >= 95) {
+			$state = "CRITICAL";
 		}
 	} else {
 		if ($health eq "DEGRADED") {
@@ -937,20 +910,6 @@ sub check_zpool() {
 	$msg = "$state $msg";
 	return ($ERRORS{$state},$msg);
 } # end check_zpool()
-
-sub check_capacity_limit() {
-	my $value = shift;
-
-	if ($value !~ /^\d+\z/) {
-		return undef;
-	}
-
-	if ($value < 1 || $value > 100) {
-		return undef;
-	}
-
-	return 1
-}
 
 ######################################################################################################
 ######################################################################################################
@@ -1122,19 +1081,19 @@ Assumes --cron --verbose if no other arguments (other than configdir) are specif
 
 Options:
 
-  --configdir=DIR       		Specify a directory to find config file sanoid.conf
+  --configdir=DIR       Specify a directory to find config file sanoid.conf
 
-  --cron                		Creates snapshots and purges expired snapshots
-  --verbose             		Prints out additional information during a sanoid run
-  --readonly            		Simulates creation/deletion of snapshots
-  --quiet               		Suppresses non-error output
-  --force-update        		Clears out sanoid's zfs snapshot cache
+  --cron                Creates snapshots and purges expired snapshots
+  --verbose             Prints out additional information during a sanoid run
+  --readonly            Simulates creation/deletion of snapshots
+  --quiet               Suppresses non-error output
+  --force-update        Clears out sanoid's zfs snapshot cache
 
-  --monitor-health[=wlimit[,climit]]    Reports on zpool "health", in a Nagios compatible format
-  --monitor-snapshots   		Reports on snapshot "health", in a Nagios compatible format
-  --take-snapshots      		Creates snapshots as specified in sanoid.conf
-  --prune-snapshots     		Purges expired snapshots as specified in sanoid.conf
+  --monitor-health      Reports on zpool "health", in a Nagios compatible format
+  --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
+  --take-snapshots      Creates snapshots as specified in sanoid.conf
+  --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
 
-  --help                		Prints this helptext
-  --version             		Prints the version number
-  --debug               		Prints out a lot of additional information during a sanoid run
+  --help                Prints this helptext
+  --version             Prints the version number
+  --debug               Prints out a lot of additional information during a sanoid run

--- a/sanoid
+++ b/sanoid
@@ -19,7 +19,7 @@ my %args = ("configdir" => "/etc/sanoid");
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
                    "monitor-health", "force-update", "configdir=s",
                    "monitor-snapshots", "take-snapshots", "prune-snapshots",
-                   "monitor-capacity:s"
+                   "monitor-capacity"
           ) or pod2usage(2);
 
 # If only config directory (or nothing) has been specified, default to --cron --verbose
@@ -53,7 +53,7 @@ my @params = ( \%config, \%snaps, \%snapsbytype, \%snapsbypath );
 if ($args{'debug'})		{ $args{'verbose'}=1; blabber (@params); }
 if ($args{'monitor-snapshots'}) { monitor_snapshots(@params); }
 if ($args{'monitor-health'}) 	{ monitor_health(@params); }
-if (defined($args{'monitor-capacity'})) { monitor_capacity(@params); }
+if ($args{'monitor-capacity'})  { monitor_capacity(@params); }
 if ($args{'force-update'}) 	{ my $snaps = getsnaps( \%config, $cacheTTL, 1 ); }
 
 if ($args{'cron'}) {
@@ -187,35 +187,39 @@ sub monitor_capacity {
 	my @messages;
 	my $errlevel=0;
 
-	my %capacitylimits = (
-		"warn"  => 80,
-		"crit" => 95
-	);
+	# build pool list with corresponding capacity limits
+	foreach my $section (keys %config) {
+		my @pool = split ('/',$section);
 
-	# if provided, parse capacity limits
-	if ($args{'monitor-capacity'} ne "") {
-		my @values = split(',', $args{'monitor-capacity'});
+		if (scalar @pool == 1 || !defined($pools{$pool[0]}) ) {
+			my %capacitylimits;
 
-		if (!check_capacity_limit($values[0])) {
-			die "ERROR: invalid zpool capacity warning limit!\n";
-		}
-		$capacitylimits{"warn"} = $values[0];
+			if (!check_capacity_limit($config{$section}{'capacity_warn'})) {
+				die "ERROR: invalid zpool capacity warning limit!\n";
+			}
 
-		if (scalar @values > 1) {
-			if (!check_capacity_limit($values[1])) {
+			if ($config{$section}{'capacity_warn'} != 0) {
+				$capacitylimits{'warn'} = $config{$section}{'capacity_warn'};
+			}
+
+			if (!check_capacity_limit($config{$section}{'capacity_crit'})) {
 				die "ERROR: invalid zpool capacity critical limit!\n";
 			}
-			$capacitylimits{"crit"} = $values[1];
-		}
-	}
 
-	foreach my $path (keys %{ $snapsbypath}) {
-		my @pool = split ('/',$path);
-		$pools{$pool[0]}=1;
+			if ($config{$section}{'capacity_crit'} != 0) {
+				$capacitylimits{'crit'} = $config{$section}{'capacity_crit'};
+			}
+
+			if (%capacitylimits) {
+				$pools{$pool[0]} = \%capacitylimits;
+			}
+		}
 	}
 
 	foreach my $pool (keys %pools) {
-		my ($exitcode, $msg) = check_zpool_capacity($pool,\%capacitylimits);
+		my $capacitylimitsref = $pools{$pool};
+
+		my ($exitcode, $msg) = check_zpool_capacity($pool,\%$capacitylimitsref);
 		if ($exitcode > $errlevel) { $errlevel = $exitcode; }
 		chomp $msg;
 		push (@messages, $msg);
@@ -956,11 +960,11 @@ sub check_zpool() {
 sub check_capacity_limit() {
 	my $value = shift;
 
-	if ($value !~ /^\d+\z/) {
+	if (!defined($value) || $value !~ /^\d+\z/) {
 		return undef;
 	}
 
-	if ($value < 1 || $value > 100) {
+	if ($value < 0 || $value > 100) {
 		return undef;
 	}
 
@@ -1004,12 +1008,16 @@ sub check_zpool_capacity() {
 	my $capn = $cap;
 	$capn =~ s/\D//g;
 
-	if ($capn >= $capacitylimits{"warn"}) {
-		$state = "WARNING";
+	if (defined($capacitylimits{"warn"})) {
+		if ($capn >= $capacitylimits{"warn"}) {
+			$state = "WARNING";
+		}
 	}
 
-	if ($capn >= $capacitylimits{"crit"}) {
-		$state = "CRITICAL";
+	if (defined($capacitylimits{"crit"})) {
+		if ($capn >= $capacitylimits{"crit"}) {
+			$state = "CRITICAL";
+		}
 	}
 
 	$msg = sprintf "ZPOOL %s : %s\n", $pool, $cap;
@@ -1187,20 +1195,20 @@ Assumes --cron --verbose if no other arguments (other than configdir) are specif
 
 Options:
 
-  --configdir=DIR                       Specify a directory to find config file sanoid.conf
+  --configdir=DIR       Specify a directory to find config file sanoid.conf
 
-  --cron                                Creates snapshots and purges expired snapshots
-  --verbose                             Prints out additional information during a sanoid run
-  --readonly                            Simulates creation/deletion of snapshots
-  --quiet                               Suppresses non-error output
-  --force-update                        Clears out sanoid's zfs snapshot cache
+  --cron                Creates snapshots and purges expired snapshots
+  --verbose             Prints out additional information during a sanoid run
+  --readonly            Simulates creation/deletion of snapshots
+  --quiet               Suppresses non-error output
+  --force-update        Clears out sanoid's zfs snapshot cache
 
-  --monitor-health                      Reports on zpool "health", in a Nagios compatible format
-  --monitor-capacity[=wlimit[,climit]]  Reports on zpool capacity, in a Nagios compatible format
-  --monitor-snapshots                   Reports on snapshot "health", in a Nagios compatible format
-  --take-snapshots                      Creates snapshots as specified in sanoid.conf
-  --prune-snapshots                     Purges expired snapshots as specified in sanoid.conf
+  --monitor-health      Reports on zpool "health", in a Nagios compatible format
+  --monitor-capacity    Reports on zpool capacity, in a Nagios compatible format
+  --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
+  --take-snapshots      Creates snapshots as specified in sanoid.conf
+  --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
 
-  --help                                Prints this helptext
-  --version                             Prints the version number
-  --debug                               Prints out a lot of additional information during a sanoid run
+  --help                Prints this helptext
+  --version             Prints the version number
+  --debug               Prints out a lot of additional information during a sanoid run

--- a/sanoid
+++ b/sanoid
@@ -18,7 +18,8 @@ use Time::Local;      # to parse dates in reverse
 my %args = ("configdir" => "/etc/sanoid");
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
                    "monitor-health", "force-update", "configdir=s",
-                   "monitor-snapshots", "take-snapshots", "prune-snapshots"
+                   "monitor-snapshots", "take-snapshots", "prune-snapshots",
+                   "monitor-capacity:s"
           ) or pod2usage(2);
 
 # If only config directory (or nothing) has been specified, default to --cron --verbose
@@ -52,6 +53,7 @@ my @params = ( \%config, \%snaps, \%snapsbytype, \%snapsbypath );
 if ($args{'debug'})		{ $args{'verbose'}=1; blabber (@params); }
 if ($args{'monitor-snapshots'}) { monitor_snapshots(@params); }
 if ($args{'monitor-health'}) 	{ monitor_health(@params); }
+if (defined($args{'monitor-capacity'})) { monitor_capacity(@params); }
 if ($args{'force-update'}) 	{ my $snaps = getsnaps( \%config, $cacheTTL, 1 ); }
 
 if ($args{'cron'}) {
@@ -172,6 +174,57 @@ sub monitor_snapshots {
 
 	print "$msg\n";
 	exit $errorlevel;
+}
+
+
+####################################################################################
+####################################################################################
+####################################################################################
+
+sub monitor_capacity {
+	my ($config, $snaps, $snapsbytype, $snapsbypath) = @_;
+	my %pools;
+	my @messages;
+	my $errlevel=0;
+
+	my %capacitylimits = (
+		"warn"  => 80,
+		"crit" => 95
+	);
+
+	# if provided, parse capacity limits
+	if ($args{'monitor-capacity'} ne "") {
+		my @values = split(',', $args{'monitor-capacity'});
+
+		if (!check_capacity_limit($values[0])) {
+			die "ERROR: invalid zpool capacity warning limit!\n";
+		}
+		$capacitylimits{"warn"} = $values[0];
+
+		if (scalar @values > 1) {
+			if (!check_capacity_limit($values[1])) {
+				die "ERROR: invalid zpool capacity critical limit!\n";
+			}
+			$capacitylimits{"crit"} = $values[1];
+		}
+	}
+
+	foreach my $path (keys %{ $snapsbypath}) {
+		my @pool = split ('/',$path);
+		$pools{$pool[0]}=1;
+	}
+
+	foreach my $pool (keys %pools) {
+		my ($exitcode, $msg) = check_zpool_capacity($pool,\%capacitylimits);
+		if ($exitcode > $errlevel) { $errlevel = $exitcode; }
+		chomp $msg;
+		push (@messages, $msg);
+	}
+
+	my @warninglevels = ('','*** WARNING *** ','*** CRITICAL *** ');
+	my $message = $warninglevels[$errlevel] . join (', ',@messages);
+	print "$message\n";
+	exit $errlevel;
 }
 
 ####################################################################################
@@ -900,6 +953,70 @@ sub check_zpool() {
 	return ($ERRORS{$state},$msg);
 } # end check_zpool()
 
+sub check_capacity_limit() {
+	my $value = shift;
+
+	if ($value !~ /^\d+\z/) {
+		return undef;
+	}
+
+	if ($value < 1 || $value > 100) {
+		return undef;
+	}
+
+	return 1
+}
+
+sub check_zpool_capacity() {
+	my %ERRORS=('DEPENDENT'=>4,'UNKNOWN'=>3,'OK'=>0,'WARNING'=>1,'CRITICAL'=>2);
+	my $state="UNKNOWN";
+	my $msg="FAILURE";
+
+	my $pool=shift;
+	my $capacitylimitsref=shift;
+	my %capacitylimits=%$capacitylimitsref;
+
+	my $statcommand="/sbin/zpool list -H -o cap $pool";
+
+	if (! open STAT, "$statcommand|") {
+		print ("$state '$statcommand' command returns no result!\n");
+		exit $ERRORS{$state};
+	}
+
+	my $line = <STAT>;
+	close(STAT);
+
+	chomp $line;
+	my @row = split(/ +/, $line);
+	my $cap=$row[0];
+
+	## check for valid capacity value
+	if ($cap !~ m/^[0-9]{1,3}%$/ ) {
+		$state = "CRITICAL";
+		$msg = sprintf "ZPOOL {%s} does not exist and/or is not responding!\n", $pool;
+		print $state, " ", $msg;
+		exit ($ERRORS{$state});
+	}
+
+	$state="OK";
+
+	# check capacity
+	my $capn = $cap;
+	$capn =~ s/\D//g;
+
+	if ($capn >= $capacitylimits{"warn"}) {
+		$state = "WARNING";
+	}
+
+	if ($capn >= $capacitylimits{"crit"}) {
+		$state = "CRITICAL";
+	}
+
+	$msg = sprintf "ZPOOL %s : %s\n", $pool, $cap;
+	$msg = "$state $msg";
+	return ($ERRORS{$state},$msg);
+} # end check_zpool_capacity()
+
 ######################################################################################################
 ######################################################################################################
 ######################################################################################################
@@ -1070,19 +1187,20 @@ Assumes --cron --verbose if no other arguments (other than configdir) are specif
 
 Options:
 
-  --configdir=DIR       Specify a directory to find config file sanoid.conf
+  --configdir=DIR                       Specify a directory to find config file sanoid.conf
 
-  --cron                Creates snapshots and purges expired snapshots
-  --verbose             Prints out additional information during a sanoid run
-  --readonly            Simulates creation/deletion of snapshots
-  --quiet               Suppresses non-error output
-  --force-update        Clears out sanoid's zfs snapshot cache
+  --cron                                Creates snapshots and purges expired snapshots
+  --verbose                             Prints out additional information during a sanoid run
+  --readonly                            Simulates creation/deletion of snapshots
+  --quiet                               Suppresses non-error output
+  --force-update                        Clears out sanoid's zfs snapshot cache
 
-  --monitor-health      Reports on zpool "health", in a Nagios compatible format
-  --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
-  --take-snapshots      Creates snapshots as specified in sanoid.conf
-  --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
+  --monitor-health                      Reports on zpool "health", in a Nagios compatible format
+  --monitor-capacity[=wlimit[,climit]]  Reports on zpool capacity, in a Nagios compatible format
+  --monitor-snapshots                   Reports on snapshot "health", in a Nagios compatible format
+  --take-snapshots                      Creates snapshots as specified in sanoid.conf
+  --prune-snapshots                     Purges expired snapshots as specified in sanoid.conf
 
-  --help                Prints this helptext
-  --version             Prints the version number
-  --debug               Prints out a lot of additional information during a sanoid run
+  --help                                Prints this helptext
+  --version                             Prints the version number
+  --debug                               Prints out a lot of additional information during a sanoid run

--- a/sanoid
+++ b/sanoid
@@ -798,6 +798,17 @@ sub check_zpool() {
 	## determine health of zpool and subsequent error status
 	if ($health eq "ONLINE" ) {
 		$state = "OK";
+
+		# check capacity
+		my $capn = $cap;
+		$capn =~ s/\D//g;
+
+		if ($capn >= 80) {
+			$state = "WARNING";
+		}
+		if ($capn >= 95) {
+			$state = "CRITICAL";
+		}
 	} else {
 		if ($health eq "DEGRADED") {
 			$state = "WARNING";

--- a/sanoid
+++ b/sanoid
@@ -17,7 +17,7 @@ use Time::Local;      # to parse dates in reverse
 
 my %args = ("configdir" => "/etc/sanoid");
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
-                   "monitor-health", "force-update", "configdir=s",
+                   "monitor-health:s", "force-update", "configdir=s",
                    "monitor-snapshots", "take-snapshots", "prune-snapshots"
           ) or pod2usage(2);
 
@@ -51,7 +51,7 @@ my @params = ( \%config, \%snaps, \%snapsbytype, \%snapsbypath );
 
 if ($args{'debug'})		{ $args{'verbose'}=1; blabber (@params); }
 if ($args{'monitor-snapshots'}) { monitor_snapshots(@params); }
-if ($args{'monitor-health'}) 	{ monitor_health(@params); }
+if (defined($args{'monitor-health'})) 	{ monitor_health(@params); }
 if ($args{'force-update'}) 	{ my $snaps = getsnaps( \%config, $cacheTTL, 1 ); }
 
 if ($args{'cron'}) {
@@ -76,13 +76,32 @@ sub monitor_health {
 	my @messages;
 	my $errlevel=0;
 
+	my %capacitylimits;
+
+	# if provided, parse capacity limits
+	if ($args{'monitor-health'} ne "") {
+		my @values = split(',', $args{'monitor-health'});
+
+		if (!check_capacity_limit($values[0])) {
+			die "ERROR: invalid zpool capacity warning limit!\n";
+		}
+		$capacitylimits{"warn"} = $values[0];
+
+		if (scalar @values > 1) {
+			if (!check_capacity_limit($values[1])) {
+				die "ERROR: invalid zpool capacity critical limit!\n";
+			}
+			$capacitylimits{"crit"} = $values[1];
+		}
+	}
+
 	foreach my $path (keys %{ $snapsbypath}) {
 		my @pool = split ('/',$path);
 		$pools{$pool[0]}=1;
 	}
 
 	foreach my $pool (keys %pools) {
-		my ($exitcode, $msg) = check_zpool($pool,2);
+		my ($exitcode, $msg) = check_zpool($pool,2,\%capacitylimits);
 		if ($exitcode > $errlevel) { $errlevel = $exitcode; }
 		chomp $msg;
 		push (@messages, $msg);
@@ -748,6 +767,8 @@ sub check_zpool() {
 
 	my $pool=shift;
 	my $verbose=shift;
+	my $capacitylimitsref=shift;
+	my %capacitylimits=%$capacitylimitsref;
 
 	my $size="";
 	my $used="";
@@ -799,15 +820,21 @@ sub check_zpool() {
 	if ($health eq "ONLINE" ) {
 		$state = "OK";
 
-		# check capacity
-		my $capn = $cap;
-		$capn =~ s/\D//g;
+		if (%capacitylimits) {
+			# check capacity
+			my $capn = $cap;
+			$capn =~ s/\D//g;
 
-		if ($capn >= 80) {
-			$state = "WARNING";
-		}
-		if ($capn >= 95) {
-			$state = "CRITICAL";
+			if ($capacitylimits{"warn"}) {
+				if ($capn >= $capacitylimits{"warn"}) {
+					$state = "WARNING";
+				}
+			}
+			if ($capacitylimits{"crit"}) {
+				if ($capn >= $capacitylimits{"crit"}) {
+					$state = "CRITICAL";
+				}
+			}
 		}
 	} else {
 		if ($health eq "DEGRADED") {
@@ -910,6 +937,20 @@ sub check_zpool() {
 	$msg = "$state $msg";
 	return ($ERRORS{$state},$msg);
 } # end check_zpool()
+
+sub check_capacity_limit() {
+	my $value = shift;
+
+	if ($value !~ /^\d+\z/) {
+		return undef;
+	}
+
+	if ($value < 1 || $value > 100) {
+		return undef;
+	}
+
+	return 1
+}
 
 ######################################################################################################
 ######################################################################################################
@@ -1081,19 +1122,19 @@ Assumes --cron --verbose if no other arguments (other than configdir) are specif
 
 Options:
 
-  --configdir=DIR       Specify a directory to find config file sanoid.conf
+  --configdir=DIR       		Specify a directory to find config file sanoid.conf
 
-  --cron                Creates snapshots and purges expired snapshots
-  --verbose             Prints out additional information during a sanoid run
-  --readonly            Simulates creation/deletion of snapshots
-  --quiet               Suppresses non-error output
-  --force-update        Clears out sanoid's zfs snapshot cache
+  --cron                		Creates snapshots and purges expired snapshots
+  --verbose             		Prints out additional information during a sanoid run
+  --readonly            		Simulates creation/deletion of snapshots
+  --quiet               		Suppresses non-error output
+  --force-update        		Clears out sanoid's zfs snapshot cache
 
-  --monitor-health      Reports on zpool "health", in a Nagios compatible format
-  --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
-  --take-snapshots      Creates snapshots as specified in sanoid.conf
-  --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
+  --monitor-health[=wlimit[,climit]]    Reports on zpool "health", in a Nagios compatible format
+  --monitor-snapshots   		Reports on snapshot "health", in a Nagios compatible format
+  --take-snapshots      		Creates snapshots as specified in sanoid.conf
+  --prune-snapshots     		Purges expired snapshots as specified in sanoid.conf
 
-  --help                Prints this helptext
-  --version             Prints the version number
-  --debug               Prints out a lot of additional information during a sanoid run
+  --help                		Prints this helptext
+  --version             		Prints the version number
+  --debug               		Prints out a lot of additional information during a sanoid run

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -70,3 +70,7 @@ monthly_warn = 32
 monthly_crit = 35
 yearly_warn = 0
 yearly_crit = 0
+
+# default limits for capacity checks (if set to 0, limit will not be checked)
+capacity_warn = 80
+capacity_crit = 95


### PR DESCRIPTION
I just noticed that the monitor-health function doesn't check the capacity, I don't know why I assumed it does but I learnt the hard way that it didn't :-/ If you are okay to check the capacity too for determining the pool health it may be best to make the limit's configurable.
I hard coded some sane defaults for now:

- \>= 80%: Warning (the 80% rule of zfs)
- \>= 95%: Critical