### PR TITLE
Added support for ZStandard compression.

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -368,6 +368,18 @@ sub compressargset {
 			decomrawcmd => '/usr/bin/pigz',
 			decomargs   => '-dc',
 		},
+		'zstd-fast' => {
+			rawcmd      => '/usr/bin/zstd',
+			args        => '-3',
+			decomrawcmd => '/usr/bin/zstd',
+			decomargs   => '-dc',
+		},
+		'zstd-slow' => {
+			rawcmd      => '/usr/bin/zstd',
+			args        => '-19',
+			decomrawcmd => '/usr/bin/zstd',
+			decomargs   => '-dc',
+		},
 		'lzo' => {
 			rawcmd      => '/usr/bin/lzop',
 			args        => '',
@@ -378,7 +390,7 @@ sub compressargset {
 
 	if ($value eq 'default') {
 		$value = $DEFAULT_COMPRESSION;
-	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'lzo', 'default', 'none'))) {
+	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'zstd-fast', 'zstd-slow', 'lzo', 'default', 'none'))) {
 		warn "Unrecognised compression value $value, defaulting to $DEFAULT_COMPRESSION";
 		$value = $DEFAULT_COMPRESSION;
 	}


### PR DESCRIPTION
Available in all major distros with a simple yum/apt-get/pkg.

References: 
ZSTD Compression by Allan Jude - https://www.youtube.com/watch?v=hWnWEitDPlM
Zstandard - https://facebook.github.io/zstd/