### PR TITLE
special char fixes #2

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -189,6 +189,7 @@ sub syncdataset {
 			return 0;
 		}
 	}
+	my $newsyncsnapescaped = escapeshellparam($newsyncsnap);
 
 	# there is currently (2014-09-01) a bug in ZFS on Linux
 	# that causes readonly to always show on if it's EVER
@@ -257,7 +258,7 @@ sub syncdataset {
 			# $originaltargetreadonly = getzfsvalue($targethost,$targetfs,$targetisroot,'readonly');
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly','on');
 
-			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnapescaped $sourcefsescaped\@$newsyncsnap";
+			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
 			$pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			$disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -325,7 +326,7 @@ sub syncdataset {
 				system ("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped");
 			}
 
-			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnap";
+			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
 			my $recvcmd = "$targetsudocmd $zfscmd receive -F $targetfsescaped";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);
@@ -909,7 +910,7 @@ sub getsnaps() {
 			my $guid = $line;
 			$guid =~ s/^.*\sguid\s*(\d*).*/$1/;
 			my $snap = $line;
-			$snap =~ s/^.*\@(\S*)\s*guid.*$/$1/;
+			$snap =~ s/^.*\@(.*)\tguid.*$/$1/;
 			$snaps{$type}{$snap}{'guid'}=$guid;
 		}
 	}
@@ -921,7 +922,7 @@ sub getsnaps() {
 			my $creation = $line;
 			$creation =~ s/^.*\screation\s*(\d*).*/$1/;
 			my $snap = $line;
-			$snap =~ s/^.*\@(\S*)\s*creation.*$/$1/;
+			$snap =~ s/^.*\@(.*)\tcreation.*$/$1/;
 			$snaps{$type}{$snap}{'creation'}=$creation;
 		}
 	}


### PR DESCRIPTION
Follow up to #176 
- The snapshot target for incremental sync's will now also be escaped
- The snapshot list creation properly parses the snapshot in case the name contains a whitespace (match tab character as delimiter for the zfs output)

So this works now:
```
$ zfs create ssd/test/src
$ zfs snapshot ssd/test/src@"spa ce"
$ zfs snapshot ssd/test/src@"spa ce " # tricky space at the end
$ zfs snapshot ssd/test/src@"spa ce "$'\t' # TAB character is luckily not allowed for snapshot name
cannot create snapshot 'ssd/test/src@spa ce     ': invalid character '  ' in name
$ zfs list ssd/test/src -r -t snapshot
NAME                   USED  AVAIL  REFER  MOUNTPOINT
ssd/test/src@spa ce      0B      -   192K  -
ssd/test/src@spa ce      0B      -   192K  -
$ ./syncoid --debug --no-sync-snap ssd/test/src ssd/test/dst
DEBUG: SSHCMD: /usr/bin/ssh    
DEBUG: checking availability of /usr/bin/lzop on source...
DEBUG: checking availability of /usr/bin/lzop on target...
DEBUG: checking availability of /usr/bin/lzop on local machine...
DEBUG: checking availability of /usr/bin/mbuffer on source...
DEBUG: checking availability of /usr/bin/mbuffer on target...
DEBUG: checking availability of /usr/bin/pv on local machine...
DEBUG: syncing source ssd/test/src to target ssd/test/dst.
DEBUG: checking to see if ssd/test/dst on  is already in zfs receive using  /bin/ps -Ao args= ...
DEBUG: checking to see if target filesystem exists using " /usr/bin/sudo /sbin/zfs get -H name 'ssd/test/dst' 2>&1 |"...
DEBUG: getting list of snapshots on ssd/test/src using  /usr/bin/sudo /sbin/zfs get -Hpd 1 -t snapshot guid,creation 'ssd/test/src' |...
NEWEST SNAPSHOT: spa ce 
DEBUG: target ssd/test/dst does not exist.  Finding oldest available snapshot on source ssd/test/src ...
DEBUG: getting estimated transfer size from source  using " /usr/bin/sudo /sbin/zfs send -nP 'ssd/test/src@spa ce' 2>&1 |"...
DEBUG: sendsize = 80496
INFO: Sending oldest full snapshot ssd/test/src@spa ce (~ 78 KB) to new target filesystem:
DEBUG: /usr/bin/sudo /sbin/zfs send 'ssd/test/src'@'spa ce' | /usr/bin/mbuffer  -q -s 128k -m 16M 2>/dev/null | /usr/bin/pv -s 80496 | /usr/bin/sudo /sbin/zfs receive -F 'ssd/test/dst'
DEBUG: checking to see if ssd/test/dst on  is already in zfs receive using  /bin/ps -Ao args= ...
45,1KiB 0:00:00 [2,77MiB/s] [=====================================================================>                                                      ] 57%            
DEBUG: getting estimated transfer size from source  using " /usr/bin/sudo /sbin/zfs send -nP -I 'ssd/test/src@spa ce' 'ssd/test/src@spa ce ' 2>&1 |"...
DEBUG: sendsize = 624
DEBUG: checking to see if ssd/test/dst on  is already in zfs receive using  /bin/ps -Ao args= ...
INFO: Updating new target filesystem with incremental ssd/test/src@spa ce ... spa ce  (~ 4 KB):
DEBUG: /usr/bin/sudo /sbin/zfs send -I 'ssd/test/src'@'spa ce' 'ssd/test/src'@'spa ce ' | /usr/bin/mbuffer  -q -s 128k -m 16M 2>/dev/null | /usr/bin/pv -s 4096 | /usr/bin/sudo /sbin/zfs receive -F 'ssd/test/dst'
1,52KiB 0:00:00 [53,2KiB/s] [==============================================>                                                                             ] 38% 
```