### PR TITLE
Document compatibility with (t)csh shells

### DIFF
--- a/FREEBSD.readme
+++ b/FREEBSD.readme
@@ -11,3 +11,14 @@ If you don't want to have to change the shebangs, your other option is to drop a
 root@bsd:~# ln -s /usr/local/bin/perl /usr/bin/perl
 
 After putting this symlink in place, ANY perl script shebanged for Linux will work on your system too.
+
+Syncoid assumes a bourne style shell on remote hosts. Using (t)csh (the default for root under FreeBSD)
+has some known issues:
+
+* If mbuffer is present, syncoid will fail with an "Ambiguous output redirect." error. So if you:
+  root@bsd:~# ln -s /usr/local/bin/mbuffer /usr/bin/mbuffer
+  make sure the remote user is using an sh compatible shell.
+
+To change to a compatible shell, use the chsh command:
+
+root@bsd:~# chsh -s /bin/sh

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ is not available on either end of the transport.
 
 On Ubuntu: apt install pv lzop mbuffer
 On CentOS: yum install lzo pv mbuffer lzop
-On FreeBSD: pkg install pv lzop
+On FreeBSD: pkg install pv mbuffer lzop
 
 FreeBSD notes: FreeBSD may place pv and lzop in somewhere other than
                /usr/bin ; syncoid currently does not check path.
@@ -18,6 +18,8 @@ FreeBSD notes: FreeBSD may place pv and lzop in somewhere other than
                root@bsd:~# ln -s /usr/local/bin/lzop /usr/bin/lzop
                or similar, as appropriate, to create links in /usr/bin
                to wherever the utilities actually are on your system.
+
+               See note about mbuffer in FREEBSD.readme
 
 
 SANOID


### PR DESCRIPTION
Also, recommend installing mbuffer on FreeBSD systems when remote user
is using bourne compatible shell.

Documents jimsalterjrs/sanoid#213