### PR TITLE
Do not require user to be specified for syncoid

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -930,20 +930,22 @@ sub getssh {
 	my $isroot;
 	my $socket;
 
-	# if we got passed something with an @ in it, we assume it's an ssh connection, eg root@myotherbox
-	if ($fs =~ /\@/) {
+	# if we got passed something with an : in it, but not at the beginning,
+	# we assume it's an ssh connection, eg root@myotherbox:pool/dataset
+	if ($fs =~ /^[^:]+:/) {
 		$rhost = $fs;
-		$fs =~ s/^\S*\@\S*://;
+		# host and usernames must not have colons
+		$fs =~ s/^[^:]*://;
 		$rhost =~ s/:\Q$fs\E$//;
-		my $remoteuser = $rhost;
-		 $remoteuser =~ s/\@.*$//;
-		if ($remoteuser eq 'root') { $isroot = 1; } else { $isroot = 0; }
+		if ($rhost =~ /^root\@/ ) { $isroot = 1; } else { $isroot = 0; }
 		# now we need to establish a persistent master SSH connection
-		$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
+		$socket = "/tmp/syncoid-$rhost-" . time();
 		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
 		close FH;
 		$rhost = "-S $socket $rhost";
 	} else {
+		# remove a leading :, if any
+		$fs =~ s/^://;
 		my $localuid = $<;
 		if ($localuid == 0) { $isroot = 1; } else { $isroot = 0; }
 	}
@@ -1130,6 +1132,12 @@ syncoid - ZFS snapshot replication tool
 
  SOURCE                Source ZFS dataset. Can be either local or remote
  TARGET                Target ZFS dataset. Can be either local or remote
+
+Notes:
+  If HOST is empty, a local dataset is assumed. This is required to specify a
+  local dataset that has a colon (:) in it, e.g.,
+
+ :poolname/dataset:name
 
 Options:
 


### PR DESCRIPTION
1. This brings the behavior of syncoid into line with the documentation, which suggests that `:`, rather than `@`, is required when specifying a remote dataset. The behavior of a TARGET or SOURCE that begins with `:` is altered to allow for local dataset names with colons in them. An example is provided in the documentation.

2. The name of the control socket is changed slightly.

3. We lose the ability to always determine if the ssh-ed user is root. This is still backwards compatible (because those configurations were not supported before), and furthermore will still function fine so long as `sudo` is installed. (I also have another PR lined up to add an option to disable `sudo`).

## Testing
Not a whole lot. It superficially runs on my configurations, and I also checked that the colon-at-the-start works in a couple cases. 