### PR TITLE
skip pruning with --no-sync-snap

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -387,9 +387,11 @@ sub syncdataset {
 		}
 	}
 
-	# prune obsolete sync snaps on source and target.
-	pruneoldsyncsnaps($sourcehost,$sourcefs,$newsyncsnap,$sourceisroot,keys %{ $snaps{'source'}});
-	pruneoldsyncsnaps($targethost,$targetfs,$newsyncsnap,$targetisroot,keys %{ $snaps{'target'}});
+	if (!defined $args{'no-sync-snap'}) {
+		# prune obsolete sync snaps on source and target (only if this run created ones).
+		pruneoldsyncsnaps($sourcehost,$sourcefs,$newsyncsnap,$sourceisroot,keys %{ $snaps{'source'}});
+		pruneoldsyncsnaps($targethost,$targetfs,$newsyncsnap,$targetisroot,keys %{ $snaps{'target'}});
+	}
 
 } # end syncdataset()
 


### PR DESCRIPTION
If syncoid is instructed to skip snapshot creation with the '--no-sync-snap' it shouldn't attempt to prune existing ones (probably from other syncoid invocations to other targets).

Fixes #196