### PR TITLE
use utc for timestamps as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 More prosaically, you can use Sanoid to create, automatically thin, and monitor snapshots and pool health from a single eminently human-readable TOML config file at /etc/sanoid/sanoid.conf.  (Sanoid also requires a "defaults" file located at /etc/sanoid/sanoid.defaults.conf, which is not user-editable.)  A typical Sanoid system would have a single cron job:
 ```
-* * * * * /usr/local/bin/sanoid --cron
+* * * * * TZ=UTC /usr/local/bin/sanoid --cron
 ```
+
+`Note`: Using UTC as timezone is recommend to prevent problems with daylight saving times
 
 And its /etc/sanoid/sanoid.conf might look something like this:
 

--- a/packages/debian/sanoid.service
+++ b/packages/debian/sanoid.service
@@ -5,5 +5,6 @@ After=zfs.target
 ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 
 [Service]
+Environment=TZ=UTC
 Type=oneshot
 ExecStart=/usr/sbin/sanoid --cron

--- a/packages/rhel/sanoid.spec
+++ b/packages/rhel/sanoid.spec
@@ -58,6 +58,7 @@ Requires=zfs.target
 After=zfs.target
 
 [Service]
+Environment=TZ=UTC
 Type=oneshot
 ExecStart=%{_sbindir}/sanoid --cron
 EOF


### PR DESCRIPTION
Update readme and systemd unit to use UTC as timezone by default. This will prevent problems with messed up scheduls due the daylight saving times (#155). It's nicer than the current WIP PR #175 which adds a suffix to duplicate snapshots times because of DST hour roll back.
If the user want's to use local time nevertheless (with the documented problem) they can override the systemd unit.

Fixes #155 
Fixed #188 