### PR TITLE
Skip parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 	This will also transfer child datasets.
 
++ --skip-parent
+
+	This will skip the syncing of the parent dataset. Does nothing without '--recursive' option.
+
 + --compress <compression type>
 
 	Currently accepted options: gzip, pigz-fast, pigz-slow, lzo (default) & none. If the selected compression method is unavailable on the source and destination, no compression will be used.

--- a/syncoid
+++ b/syncoid
@@ -1142,7 +1142,7 @@ Options:
 
   --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, lzo (default) & none
   --recursive|r         Also transfers child datasets
-  --skip-parent         Skipp the syncing of the parent dataset. Doesg nothing without '--recursive' option.
+  --skip-parent         Skips syncing of the parent dataset. Does nothing without '--recursive' option.
   --source-bwlimit=<limit k|m|g|t>  Bandwidth limit on the source transfer
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer
   --no-stream           Replicates using newest snapshot instead of intermediates

--- a/syncoid
+++ b/syncoid
@@ -19,7 +19,7 @@ use Sys::Hostname;
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume") or pod2usage(2);
+                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "skip-parent") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -140,6 +140,11 @@ sub getchilddatasets {
 	open FH, $getchildrencmd;
 	my @children = <FH>;
 	close FH;
+
+	if (defined $args{'skip-parent'}) {
+		# parent dataset is the first element
+		shift @children;
+	}
 
 	return @children;
 }
@@ -1137,6 +1142,7 @@ Options:
 
   --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, lzo (default) & none
   --recursive|r         Also transfers child datasets
+  --skip-parent         Skipp the syncing of the parent dataset. Doesg nothing without '--recursive' option.
   --source-bwlimit=<limit k|m|g|t>  Bandwidth limit on the source transfer
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit on the target transfer
   --no-stream           Replicates using newest snapshot instead of intermediates


### PR DESCRIPTION
New option "--skip-parent" for skipping the parent dataset from recursive replication.

Fixes #231