### PR TITLE
fixed monitor-health command for pools containing cache and log devices

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -976,6 +976,11 @@ sub check_zpool() {
 			## other cases
 			my ($dev, $sta) = /^\s+(\S+)\s+(\S+)/;
 
+			if (!defined($sta)) {
+				# cache and logs are special and don't have a status
+				next;
+			}
+
 			## pool online, not degraded thanks to dead/corrupted disk
 			if ($state eq "OK" && $sta eq "UNAVAIL") {
 				$state="WARNING";
@@ -1111,7 +1116,7 @@ sub checklock {
 	# make sure lockfile contains something
 	if ( -z $lockfile) {
 	        # zero size lockfile, something is wrong
-	        die "ERROR: something is wrong! $lockfile is empty\n"; 
+	        die "ERROR: something is wrong! $lockfile is empty\n";
 	}
 
 	# lockfile exists. read pid and mutex from it. see if it's our pid.  if not, see if


### PR DESCRIPTION
I just started using (testing) log and cache devices. Right after icinga started to complain because --monitor-health doesn't correctly parses the output in the case where those special vdevs are used.
The following is the status output of my zpool. The logs and cache line doesn't contain a state so this is where the parsing fails with "unitialized variable" errors, which will shadow the ordinary icinga style output.

```
  pool: storage
 state: ONLINE
  scan: scrub repaired 0B in 36h43m with 0 errors on Mon Jun 11 13:07:29 2018
config:

        NAME                                                      STATE     READ WRITE CKSUM
        storage                                                   ONLINE       0     0     0
          mirror-0                                                ONLINE       0     0     0
            ata-ST3000VX000-xxxxxxxxxxxxxxx                       ONLINE       0     0     0
            ata-WDC_WD30EURS-xxxxxxxxxxxxxxxxxxxxxxx              ONLINE       0     0     0
          mirror-1                                                ONLINE       0     0     0
            ata-WDC_WD30EURS-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx        ONLINE       0     0     0
            ata-WDC_WD30EURS-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx        ONLINE       0     0     0
        logs
          mirror-2                                                ONLINE       0     0     0
            ata-Samsung_SSD_840_PRO_xxxxxxxxxxxxxxxxxxxxxxxxxxxx  ONLINE       0     0     0
            ata-Samsung_SSD_840_PRO_xxxxxxxxxxxxxxxxxxxxxxxxxxxx  ONLINE       0     0     0
        cache
          ata-Samsung_SSD_840_PRO_xxxxxxxxxxxxxxxxxxxxxxxxxxxx    ONLINE       0     0     0
          ata-Samsung_SSD_840_PRO_xxxxxxxxxxxxxxxxxxxxxxxxxxxx    ONLINE       0     0     0

errors: No known data errors
```