### PR TITLE
Fix 'resume support' detection on FreeBSD

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -614,7 +614,7 @@ sub checkcommands {
 
 	# check for ZFS resume feature support
 	if ($resume) {
-		my $resumechkcmd = "$zfscmd get receive_resume_token -d 0";
+		my $resumechkcmd = "$zfscmd get -d 0 receive_resume_token";
 
 		if ($debug) { print "DEBUG: checking availability of zfs resume feature on source...\n"; }
 		$avail{'sourceresume'} = system("$sourcessh $resumechkcmd >/dev/null 2>&1");


### PR DESCRIPTION
FreeBSD does not accept options at the end, so without this fix it always fails:

```
$ uname -sr
FreeBSD 11.2-RELEASE
$ /sbin/zfs get receive_resume_token -d 0
cannot open '-d': dataset does not exist
cannot open '0': dataset does not exist
$ /sbin/zfs get -d 0 receive_resume_token
NAME      PROPERTY              VALUE      SOURCE
newzroot  receive_resume_token  -          -
```