### PR TITLE
fixed typo

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -863,7 +863,7 @@ sub pruneoldsyncsnaps {
 				$prunecmd = escapeshellparam($prunecmd);
 			}
 			system("$rhost $prunecmd") == 0
-				or warn "CRITICAL ERROR: $rhost $prunecmd failed: $?";
+				or warn "WARNING: $rhost $prunecmd failed: $?";
 			$prunecmd = '';
 			$counter = 0;
 		}


### PR DESCRIPTION
bring the warning output in line with the following one which warns about the same thing