### PR TITLE
continue recursive replication if some datasets fail

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -97,6 +97,7 @@ my $targetsudocmd = $targetisroot ? '' : $sudocmd;
 my %avail = checkcommands();
 
 my %snaps;
+my $exitcode = 0;
 
 ## break here to call replication individually so that we ##
 ## can loop across children separately, for recursive     ##
@@ -127,7 +128,7 @@ if ($targethost ne '') {
 	close FH;
 }
 
-exit 0;
+exit $exitcode;
 
 ##############################################################################
 ##############################################################################
@@ -186,6 +187,7 @@ sub syncdataset {
 	# make sure target is not currently in receive.
 	if (iszfsbusy($targethost,$targetfs,$targetisroot)) {
 		warn "Cannot sync now: $targetfs is already target of a zfs receive process.\n";
+		if ($exitcode < 1) { $exitcode = 1; }
 		return 0;
 	}
 
@@ -236,6 +238,7 @@ sub syncdataset {
 			$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
 			if ($newsyncsnap eq 0) {
 				warn "CRITICAL: no snapshots exist on source $sourcefs, and you asked for --no-sync-snap.\n";
+				if ($exitcode < 1) { $exitcode = 1; }
 				return 0;
 			}
 		}
@@ -292,6 +295,7 @@ sub syncdataset {
 		# make sure target is (still) not currently in receive.
 		if (iszfsbusy($targethost,$targetfs,$targetisroot)) {
 			warn "Cannot sync now: $targetfs is already target of a zfs receive process.\n";
+			if ($exitcode < 1) { $exitcode = 1; }
 			return 0;
 		}
 		system($synccmd) == 0
@@ -318,6 +322,7 @@ sub syncdataset {
 			# make sure target is (still) not currently in receive.
 			if (iszfsbusy($targethost,$targetfs,$targetisroot)) {
 				warn "Cannot sync now: $targetfs is already target of a zfs receive process.\n";
+				if ($exitcode < 1) { $exitcode = 1; }
 				return 0;
 			}
 
@@ -325,9 +330,12 @@ sub syncdataset {
 			if ($debug) { print "DEBUG: $synccmd\n"; }
 
 			if ($oldestsnap ne $newsyncsnap) {
-				system($synccmd) == 0
-					or warn "CRITICAL ERROR: $synccmd failed: $?";
+				my $ret = system($synccmd);
+				if ($ret != 0) {
+					warn "CRITICAL ERROR: $synccmd failed: $?";
+					if ($exitcode < 1) { $exitcode = 1; }
 					return 0;
+				}
 			} else {
 				if (!$quiet) { print "INFO: no incremental sync needed; $oldestsnap is already the newest available snapshot.\n"; }
 			}
@@ -380,6 +388,7 @@ sub syncdataset {
 		# make sure target is (still) not currently in receive.
 		if (iszfsbusy($targethost,$targetfs,$targetisroot)) {
 			warn "Cannot sync now: $targetfs is already target of a zfs receive process.\n";
+			if ($exitcode < 1) { $exitcode = 1; }
 			return 0;
 		}
 
@@ -910,6 +919,7 @@ sub getmatchingsnapshot {
 	}
 
 	# if we got this far, we failed to find a matching snapshot.
+	if ($exitcode < 2) { $exitcode = 2; }
 
 	print "\n";
 	print "CRITICAL ERROR: Target $targetfs exists but has no snapshots matching with $sourcefs!\n";

--- a/syncoid
+++ b/syncoid
@@ -233,6 +233,10 @@ sub syncdataset {
 		if (!defined $args{'no-sync-snap'}) {
 			# create a new syncoid snapshot on the source filesystem.
 			$newsyncsnap = newsyncsnap($sourcehost,$sourcefs,$sourceisroot);
+			if (!$newsyncsnap) {
+				# we already whined about the error
+				return 0;
+			}
 		} else {
 			# we don't want sync snapshots created, so use the newest snapshot we can find.
 			$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
@@ -267,6 +271,11 @@ sub syncdataset {
 		}
 		my $oldestsnap = getoldestsnapshot(\%snaps);
 		if (! $oldestsnap) {
+			if (defined ($args{'no-sync-snap'}) ) {
+				# we already whined about the missing snapshots
+				return 0;
+			}
+
 			# getoldestsnapshot() returned false, so use new sync snapshot
 			if ($debug) { print "DEBUG: getoldestsnapshot() returned false, so using $newsyncsnap.\n"; }
 			$oldestsnap = $newsyncsnap;
@@ -752,7 +761,7 @@ sub getoldestsnapshot {
 	# must not have had any snapshots on source - luckily, we already made one, amirite?
 	if (defined ($args{'no-sync-snap'}) ) {
 		# well, actually we set --no-sync-snap, so no we *didn't* already make one. Whoops.
-		die "CRIT: --no-sync-snap is set, and getoldestsnapshot() could not find any snapshots on source!\n";
+		warn "CRIT: --no-sync-snap is set, and getoldestsnapshot() could not find any snapshots on source!\n";
 	}
 	return 0;
 }
@@ -774,6 +783,7 @@ sub getnewestsnapshot {
 		#        we also probably need an argument to mute this WARN, for people who deliberately exclude
 		#        datasets from recursive replication this way.
 		warn "WARN: --no-sync-snap is set, and getnewestsnapshot() could not find any snapshots on source for current dataset. Continuing.\n";
+		if ($exitcode < 2) { $exitcode = 2; }
 	}
 	return 0;
 }
@@ -961,8 +971,12 @@ sub newsyncsnap {
 	my %date = getdate();
 	my $snapname = "syncoid\_$identifier$hostid\_$date{'stamp'}";
 	my $snapcmd = "$rhost $mysudocmd $zfscmd snapshot $fsescaped\@$snapname\n";
-	system($snapcmd) == 0
-		or die "CRITICAL ERROR: $snapcmd failed: $?";
+	system($snapcmd) == 0 or do {
+		warn "CRITICAL ERROR: $snapcmd failed: $?";
+		if ($exitcode < 2) { $exitcode = 2; }
+		return 0;
+	};
+
 	return $snapname;
 }
 

--- a/syncoid
+++ b/syncoid
@@ -298,8 +298,11 @@ sub syncdataset {
 			if ($exitcode < 1) { $exitcode = 1; }
 			return 0;
 		}
-		system($synccmd) == 0
-			or die "CRITICAL ERROR: $synccmd failed: $?";
+		system($synccmd) == 0 or do {
+			warn "CRITICAL ERROR: $synccmd failed: $?";
+			if ($exitcode < 2) { $exitcode = 2; }
+			return 0;
+		};
 
 		# now do an -I to the new sync snapshot, assuming there were any snapshots
 		# other than the new sync snapshot to begin with, of course - and that we
@@ -359,8 +362,11 @@ sub syncdataset {
 
 		    if (!$quiet) { print "Resuming interrupted zfs send/receive from $sourcefs to $targetfs (~ $disp_pvsize remaining):\n"; }
 		    if ($debug) { print "DEBUG: $synccmd\n"; }
-		    system("$synccmd") == 0
-		        or die "CRITICAL ERROR: $synccmd failed: $?";
+		    system("$synccmd") == 0 or do {
+		        warn "CRITICAL ERROR: $synccmd failed: $?";
+		        if ($exitcode < 2) { $exitcode = 2; }
+		        return 0;
+		    };
 
 		    # a resumed transfer will only be done to the next snapshot,
 		    # so do an normal sync cycle
@@ -416,8 +422,11 @@ sub syncdataset {
 
 			if (!$quiet) { print "Sending incremental $sourcefs\@$matchingsnap ... $newsyncsnap (~ $disp_pvsize):\n"; }
 			if ($debug) { print "DEBUG: $synccmd\n"; }
-			system("$synccmd") == 0
-				or die "CRITICAL ERROR: $synccmd failed: $?";
+			system("$synccmd") == 0 or do {
+				warn "CRITICAL ERROR: $synccmd failed: $?";
+				if ($exitcode < 2) { $exitcode = 2; }
+				return 0;
+			};
 
 			# restore original readonly value to target after sync complete
 				# dyking this functionality out for the time being due to buggy mount/unmount behavior


### PR DESCRIPTION
If there are problem with replication single datasets it shouldn't abort the whole recursive replication but try all and then fail with an failure exit code.

Note: this is based on another PR because it shares some common code, so the former should be merge first

Requires/Based on PR: #249 
Fixes #240 