### PR TITLE
ignore unknown interval type to prevent perl warnings

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -471,7 +471,7 @@ sub take_snapshots {
 					$lastpreferred = timelocal(@preferredtime);
 					if ($lastpreferred > time()) { $lastpreferred -= 60*60*24*31*365.25; } # preferred time is later this year - so look at last year
 				} else {
-					# unknown type
+					warn "WARN: unknown interval type $type in config!";
 					next;
 				}
 

--- a/sanoid
+++ b/sanoid
@@ -438,6 +438,9 @@ sub take_snapshots {
 					push @preferredtime,$datestamp{'year'};
 					$lastpreferred = timelocal(@preferredtime);
 					if ($lastpreferred > time()) { $lastpreferred -= 60*60*24*31*365.25; } # preferred time is later this year - so look at last year
+				} else {
+					# unknown type
+					next;
 				}
 
 				# reconstruct our human-formatted most recent preferred snapshot time into an epoch time, to compare with the epoch of our most recent snapshot


### PR DESCRIPTION
In my case, I have "frequently" key values in the config, but the release version doesn't support them but they are iterated and used which leads to perl warnings about uninitialized values. So just skip processing unknown interval types.