### PR TITLE
Ignore snapshots types that are set to 0.

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -127,6 +127,7 @@ sub monitor_snapshots {
 
 		my @types = ('yearly','monthly','daily','hourly');
 		foreach my $type (@types) {
+			if ($config{$section}{$type} == 0) { next; }
 
 			my $smallerperiod = 0;
 			# we need to set the period length in seconds first


### PR DESCRIPTION
I am only using monthly snapshots and would like to use `--monitor-snapshots` to ensure operation. Below shows my config:

```
[tank/Backup]
  use_template = backup

#############################
# templates below this line #
#############################

[template_backup]
  hourly = 0
  daily = 0
  monthly = 6
  yearly = 0
  autosnap = yes
  autoprune = yes

[template_replica]
  hourly = 0
  daily = 0
  monthly = 8
  yearly = 0
  autosnap = no
  autoprune = yes
```

However, `--monitor-snapshots` fails with:

```
CRIT: tank/Backup has no daily snapshots at all!, CRIT: tank/Backup has no hourly snapshots at all!
```

In this case, I would expect to not have daily or hourly snapshots. This PR fixes the above by skipping checks for snapshot types where the number of snapshots is 0 (or negative - I wasn't sure if that was a valid use case).