### PR TITLE
Add in poweruser --sendoptions=OPTIONS and --recvoptions=OPTIONS

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # this software is licensed for use under the Free Software Foundation's GPL v3.0 license, as retrieved
-# from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this
+# from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.	A copy should also be available in this
 # project's Git repository at https://github.com/jimsalterjrs/sanoid/blob/master/LICENSE.
 
 $::VERSION = '1.4.18';
@@ -18,10 +18,21 @@ use Sys::Hostname;
 # TODO: Merge into a single "sshflags" option?
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r",
-                   "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s") or pod2usage(2);
+                   "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@", "sendoptions=s",
+                   "recvoptions=s", "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent",
+                   "identifier=s") or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
+
+my $sendoptions = '';
+if (length $args{'sendoptions'}) {
+	$sendoptions = $args{'sendoptions'}
+}
+
+my $recvoptions = '';
+if (length $args{'recvoptions'}) {
+	$sendoptions = $args{'recvoptions'}
+}
 
 # TODO Expand to accept multiple sources?
 if (scalar(@ARGV) != 2) {
@@ -64,7 +75,7 @@ if (length $args{'sshcipher'}) {
 	$args{'sshcipher'} = "-c $args{'sshcipher'}";
 }
 if (length $args{'sshport'}) {
-  $args{'sshport'} = "-p $args{'sshport'}";
+	$args{'sshport'} = "-p $args{'sshport'}";
 }
 if (length $args{'sshkey'}) {
 	$args{'sshkey'} = "-i $args{'sshkey'}";
@@ -236,15 +247,15 @@ sub syncdataset {
 		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
 
 		if ($targetexists) {
-		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
-		    my %sourcesnaps = %snaps;
-		    %snaps = (%sourcesnaps, %targetsnaps);
+			my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
+			my %sourcesnaps = %snaps;
+			%snaps = (%sourcesnaps, %targetsnaps);
 		}
 
 		if (defined $args{'dumpsnaps'}) {
-		    print "merged snapshot list of $targetfs: \n";
-		    dumphash(\%snaps);
-		    print "\n\n\n";
+			print "merged snapshot list of $targetfs: \n";
+			dumphash(\%snaps);
+			print "\n\n\n";
 		}
 
 		if (!defined $args{'no-sync-snap'}) {
@@ -281,9 +292,9 @@ sub syncdataset {
 		# THEN do an -I to the newest
 		if ($debug) {
 			if (!defined ($args{'no-stream'}) ) {
-				print "DEBUG: target $targetfs does not exist.  Finding oldest available snapshot on source $sourcefs ...\n";
+				print "DEBUG: target $targetfs does not exist.	Finding oldest available snapshot on source $sourcefs ...\n";
 			} else {
-				print "DEBUG: target $targetfs does not exist, and --no-stream selected.  Finding newest available snapshot on source $sourcefs ...\n";
+				print "DEBUG: target $targetfs does not exist, and --no-stream selected.	Finding newest available snapshot on source $sourcefs ...\n";
 			}
 		}
 		my $oldestsnap = getoldestsnapshot(\%snaps);
@@ -302,8 +313,8 @@ sub syncdataset {
 		if (defined $args{'no-stream'}) { $oldestsnap = getnewestsnapshot(\%snaps); }
 		my $oldestsnapescaped = escapeshellparam($oldestsnap);
 
-		my $sendcmd = "$sourcesudocmd $zfscmd send $sourcefsescaped\@$oldestsnapescaped";
-		my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
+		my $sendcmd = "$sourcesudocmd $zfscmd send $sendoptions $sourcefsescaped\@$oldestsnapescaped";
+		my $recvcmd = "$targetsudocmd $zfscmd receive $recvoptions $receiveextraargs -F $targetfsescaped";
 
 		my $pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap",0,$sourceisroot);
 		my $disp_pvsize = readablebytes($pvsize);
@@ -342,7 +353,7 @@ sub syncdataset {
 			# $originaltargetreadonly = getzfsvalue($targethost,$targetfs,$targetisroot,'readonly');
 			# setzfsvalue($targethost,$targetfs,$targetisroot,'readonly','on');
 
-			$sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$oldestsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
+			$sendcmd = "$sourcesudocmd $zfscmd send $sendoptions $args{'streamarg'} $sourcefsescaped\@$oldestsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
 			$pvsize = getsendsize($sourcehost,"$sourcefs\@$oldestsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			$disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -379,24 +390,24 @@ sub syncdataset {
 		# and because this will ony resume the receive to the next
 		# snapshot, do a normal sync after that
 		if (defined($receivetoken)) {
-		    my $sendcmd = "$sourcesudocmd $zfscmd send -t $receivetoken";
-		    my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
-		    my $pvsize = getsendsize($sourcehost,"","",$sourceisroot,$receivetoken);
-		    my $disp_pvsize = readablebytes($pvsize);
-		    if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
-		    my $synccmd = buildsynccmd($sendcmd,$recvcmd,$pvsize,$sourceisroot,$targetisroot);
+			my $sendcmd = "$sourcesudocmd $zfscmd send -t $receivetoken";
+			my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
+			my $pvsize = getsendsize($sourcehost,"","",$sourceisroot,$receivetoken);
+			my $disp_pvsize = readablebytes($pvsize);
+			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
+			my $synccmd = buildsynccmd($sendcmd,$recvcmd,$pvsize,$sourceisroot,$targetisroot);
 
-		    if (!$quiet) { print "Resuming interrupted zfs send/receive from $sourcefs to $targetfs (~ $disp_pvsize remaining):\n"; }
-		    if ($debug) { print "DEBUG: $synccmd\n"; }
-		    system("$synccmd") == 0 or do {
-		        warn "CRITICAL ERROR: $synccmd failed: $?";
-		        if ($exitcode < 2) { $exitcode = 2; }
-		        return 0;
-		    };
+			if (!$quiet) { print "Resuming interrupted zfs send/receive from $sourcefs to $targetfs (~ $disp_pvsize remaining):\n"; }
+			if ($debug) { print "DEBUG: $synccmd\n"; }
+			system("$synccmd") == 0 or do {
+				warn "CRITICAL ERROR: $synccmd failed: $?";
+				if ($exitcode < 2) { $exitcode = 2; }
+				return 0;
+			};
 
-		    # a resumed transfer will only be done to the next snapshot,
-		    # so do an normal sync cycle
-		    return syncdataset($sourcehost, $sourcefs, $targethost, $targetfs);
+			# a resumed transfer will only be done to the next snapshot,
+			# so do an normal sync cycle
+			return syncdataset($sourcehost, $sourcefs, $targethost, $targetfs);
 		}
 
 		# find most recent matching snapshot and do an -I
@@ -439,8 +450,8 @@ sub syncdataset {
 				system ("$targetsudocmd $zfscmd rollback -R $targetfsescaped\@$matchingsnapescaped");
 			}
 
-			my $sendcmd = "$sourcesudocmd $zfscmd send $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
-			my $recvcmd = "$targetsudocmd $zfscmd receive $receiveextraargs -F $targetfsescaped";
+			my $sendcmd = "$sourcesudocmd $zfscmd send $sendoptions $args{'streamarg'} $sourcefsescaped\@$matchingsnapescaped $sourcefsescaped\@$newsyncsnapescaped";
+			my $recvcmd = "$targetsudocmd $zfscmd receive $recvoptions $receiveextraargs -F $targetfsescaped";
 			my $pvsize = getsendsize($sourcehost,"$sourcefs\@$matchingsnap","$sourcefs\@$newsyncsnap",$sourceisroot);
 			my $disp_pvsize = readablebytes($pvsize);
 			if ($pvsize == 0) { $disp_pvsize = "UNKNOWN"; }
@@ -474,46 +485,46 @@ sub compressargset {
 	my $DEFAULT_COMPRESSION = 'lzo';
 	my %COMPRESS_ARGS = (
 		'none' => {
-			rawcmd      => '',
-			args        => '',
+			rawcmd		=> '',
+			args		=> '',
 			decomrawcmd => '',
-			decomargs   => '',
+			decomargs	=> '',
 		},
 		'gzip' => {
-			rawcmd      => '/bin/gzip',
-			args        => '-3',
+			rawcmd		=> '/bin/gzip',
+			args		=> '-3',
 			decomrawcmd => '/bin/zcat',
-			decomargs   => '',
+			decomargs	=> '',
 		},
 		'pigz-fast' => {
-			rawcmd      => '/usr/bin/pigz',
-			args        => '-3',
+			rawcmd		=> '/usr/bin/pigz',
+			args		=> '-3',
 			decomrawcmd => '/usr/bin/pigz',
-			decomargs   => '-dc',
+			decomargs	=> '-dc',
 		},
 		'pigz-slow' => {
-			rawcmd      => '/usr/bin/pigz',
-			args        => '-9',
+			rawcmd		=> '/usr/bin/pigz',
+			args		=> '-9',
 			decomrawcmd => '/usr/bin/pigz',
-			decomargs   => '-dc',
+			decomargs	=> '-dc',
 		},
 		'zstd-fast' => {
-			rawcmd      => '/usr/bin/zstd',
-			args        => '-3',
+			rawcmd		=> '/usr/bin/zstd',
+			args		=> '-3',
 			decomrawcmd => '/usr/bin/zstd',
-			decomargs   => '-dc',
+			decomargs	=> '-dc',
 		},
 		'zstd-slow' => {
-			rawcmd      => '/usr/bin/zstd',
-			args        => '-19',
+			rawcmd		=> '/usr/bin/zstd',
+			args		=> '-19',
 			decomrawcmd => '/usr/bin/zstd',
-			decomargs   => '-dc',
+			decomargs	=> '-dc',
 		},
 		'lzo' => {
-			rawcmd      => '/usr/bin/lzop',
-			args        => '',
+			rawcmd		=> '/usr/bin/lzop',
+			args		=> '',
 			decomrawcmd => '/usr/bin/lzop',
-			decomargs   => '-dfc',
+			decomargs	=> '-dfc',
 		},
 	);
 
@@ -526,7 +537,7 @@ sub compressargset {
 
 	my %comargs = %{$COMPRESS_ARGS{$value}}; # copy
 	$comargs{'compress'} = $value;
-	$comargs{'cmd'}      = "$comargs{'rawcmd'} $comargs{'args'}";
+	$comargs{'cmd'}		 = "$comargs{'rawcmd'} $comargs{'args'}";
 	$comargs{'decomcmd'} = "$comargs{'decomrawcmd'} $comargs{'decomargs'}";
 	return \%comargs;
 }
@@ -797,8 +808,8 @@ sub getnewestsnapshot {
 			die "CRIT: --no-sync-snap is set, and getnewestsnapshot() could not find any snapshots on source!\n";
 		}
 		# fixme: we need to output WHAT the current dataset IS if we encounter this WARN condition.
-		#        we also probably need an argument to mute this WARN, for people who deliberately exclude
-		#        datasets from recursive replication this way.
+		#		 we also probably need an argument to mute this WARN, for people who deliberately exclude
+		#		 datasets from recursive replication this way.
 		warn "WARN: --no-sync-snap is set, and getnewestsnapshot() could not find any snapshots on source for current dataset. Continuing.\n";
 		if ($exitcode < 2) { $exitcode = 2; }
 	}
@@ -959,17 +970,17 @@ sub getmatchingsnapshot {
 
 	print "\n";
 	print "CRITICAL ERROR: Target $targetfs exists but has no snapshots matching with $sourcefs!\n";
-	print "                Replication to target would require destroying existing\n";
-	print "                target. Cowardly refusing to destroy your existing target.\n\n";
+	print "					 Replication to target would require destroying existing\n";
+	print "					 target. Cowardly refusing to destroy your existing target.\n\n";
 
 	# experience tells me we need a mollyguard for people who try to
 	# zfs create targetpool/targetsnap ; syncoid sourcepool/sourcesnap targetpool/targetsnap ...
 
 	if ( $targetsize < (64*1024*1024) ) {
-		print "          NOTE: Target $targetfs dataset is < 64MB used - did you mistakenly run\n";
-		print "                \`zfs create $args{'target'}\` on the target? ZFS initial\n";
-		print "                replication must be to a NON EXISTENT DATASET, which will\n";
-		print "                then be CREATED BY the initial replication process.\n\n";
+		print "			 NOTE: Target $targetfs dataset is < 64MB used - did you mistakenly run\n";
+		print "					 \`zfs create $args{'target'}\` on the target? ZFS initial\n";
+		print "					 replication must be to a NON EXISTENT DATASET, which will\n";
+		print "					 then be CREATED BY the initial replication process.\n\n";
 	}
 	return 0;
 }
@@ -1133,7 +1144,7 @@ sub getsendsize {
 		$snaps = "-t $receivetoken";
 	}
 
-	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send -nP $snaps";
+	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send $sendoptions -nP $snaps";
 	if ($debug) { print "DEBUG: getting estimated transfer size from source $sourcehost using \"$getsendsizecmd 2>&1 |\"...\n"; }
 
 	open FH, "$getsendsizecmd 2>&1 |";
@@ -1203,8 +1214,8 @@ sub getreceivetoken() {
 	}
 
 	if ($debug) {
-        print "DEBUG: no receive token found \n";
-    }
+		print "DEBUG: no receive token found \n";
+	}
 
 	return
 }
@@ -1236,6 +1247,8 @@ Options:
   --no-stream           Replicates using newest snapshot instead of intermediates
   --no-sync-snap        Does not create new snapshot, only transfers existing
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times
+  --sendoptions=OPTIONS  DANGER: Inject OPTIONS into zfs send, e.g. syncoid --sendoptions="-Lce" sets zfs send -Lce ...
+  --recvoptions=OPTIONS  DANGER: Inject OPTIONS into zfs received, e.g. syncoid --recvoptions="-x property" sets zfs receive -x property ...
 
   --sshkey=FILE         Specifies a ssh public key to use to connect
   --sshport=PORT        Connects to remote on a particular port

--- a/syncoid
+++ b/syncoid
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # this software is licensed for use under the Free Software Foundation's GPL v3.0 license, as retrieved
-# from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.	A copy should also be available in this
+# from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this
 # project's Git repository at https://github.com/jimsalterjrs/sanoid/blob/master/LICENSE.
 
 $::VERSION = '1.4.18';
@@ -292,9 +292,9 @@ sub syncdataset {
 		# THEN do an -I to the newest
 		if ($debug) {
 			if (!defined ($args{'no-stream'}) ) {
-				print "DEBUG: target $targetfs does not exist.	Finding oldest available snapshot on source $sourcefs ...\n";
+				print "DEBUG: target $targetfs does not exist.  Finding oldest available snapshot on source $sourcefs ...\n";
 			} else {
-				print "DEBUG: target $targetfs does not exist, and --no-stream selected.	Finding newest available snapshot on source $sourcefs ...\n";
+				print "DEBUG: target $targetfs does not exist, and --no-stream selected.  Finding newest available snapshot on source $sourcefs ...\n";
 			}
 		}
 		my $oldestsnap = getoldestsnapshot(\%snaps);
@@ -485,46 +485,46 @@ sub compressargset {
 	my $DEFAULT_COMPRESSION = 'lzo';
 	my %COMPRESS_ARGS = (
 		'none' => {
-			rawcmd		=> '',
-			args		=> '',
+			rawcmd      => '',
+			args        => '',
 			decomrawcmd => '',
-			decomargs	=> '',
+			decomargs   => '',
 		},
 		'gzip' => {
-			rawcmd		=> '/bin/gzip',
-			args		=> '-3',
+			rawcmd      => '/bin/gzip',
+			args        => '-3',
 			decomrawcmd => '/bin/zcat',
-			decomargs	=> '',
+			decomargs   => '',
 		},
 		'pigz-fast' => {
-			rawcmd		=> '/usr/bin/pigz',
-			args		=> '-3',
+			rawcmd      => '/usr/bin/pigz',
+			args        => '-3',
 			decomrawcmd => '/usr/bin/pigz',
-			decomargs	=> '-dc',
+			decomargs   => '-dc',
 		},
 		'pigz-slow' => {
-			rawcmd		=> '/usr/bin/pigz',
-			args		=> '-9',
+			rawcmd      => '/usr/bin/pigz',
+			args        => '-9',
 			decomrawcmd => '/usr/bin/pigz',
-			decomargs	=> '-dc',
+			decomargs   => '-dc',
 		},
 		'zstd-fast' => {
-			rawcmd		=> '/usr/bin/zstd',
-			args		=> '-3',
+			rawcmd      => '/usr/bin/zstd',
+			args        => '-3',
 			decomrawcmd => '/usr/bin/zstd',
-			decomargs	=> '-dc',
+			decomargs   => '-dc',
 		},
 		'zstd-slow' => {
-			rawcmd		=> '/usr/bin/zstd',
-			args		=> '-19',
+			rawcmd      => '/usr/bin/zstd',
+			args        => '-19',
 			decomrawcmd => '/usr/bin/zstd',
-			decomargs	=> '-dc',
+			decomargs   => '-dc',
 		},
 		'lzo' => {
-			rawcmd		=> '/usr/bin/lzop',
-			args		=> '',
+			rawcmd      => '/usr/bin/lzop',
+			args        => '',
 			decomrawcmd => '/usr/bin/lzop',
-			decomargs	=> '-dfc',
+			decomargs   => '-dfc',
 		},
 	);
 
@@ -537,7 +537,7 @@ sub compressargset {
 
 	my %comargs = %{$COMPRESS_ARGS{$value}}; # copy
 	$comargs{'compress'} = $value;
-	$comargs{'cmd'}		 = "$comargs{'rawcmd'} $comargs{'args'}";
+	$comargs{'cmd'}      = "$comargs{'rawcmd'} $comargs{'args'}";
 	$comargs{'decomcmd'} = "$comargs{'decomrawcmd'} $comargs{'decomargs'}";
 	return \%comargs;
 }
@@ -808,8 +808,8 @@ sub getnewestsnapshot {
 			die "CRIT: --no-sync-snap is set, and getnewestsnapshot() could not find any snapshots on source!\n";
 		}
 		# fixme: we need to output WHAT the current dataset IS if we encounter this WARN condition.
-		#		 we also probably need an argument to mute this WARN, for people who deliberately exclude
-		#		 datasets from recursive replication this way.
+		#        we also probably need an argument to mute this WARN, for people who deliberately exclude
+		#        datasets from recursive replication this way.
 		warn "WARN: --no-sync-snap is set, and getnewestsnapshot() could not find any snapshots on source for current dataset. Continuing.\n";
 		if ($exitcode < 2) { $exitcode = 2; }
 	}
@@ -970,17 +970,17 @@ sub getmatchingsnapshot {
 
 	print "\n";
 	print "CRITICAL ERROR: Target $targetfs exists but has no snapshots matching with $sourcefs!\n";
-	print "					 Replication to target would require destroying existing\n";
-	print "					 target. Cowardly refusing to destroy your existing target.\n\n";
+	print "                Replication to target would require destroying existing\n";
+	print "                target. Cowardly refusing to destroy your existing target.\n\n";
 
 	# experience tells me we need a mollyguard for people who try to
 	# zfs create targetpool/targetsnap ; syncoid sourcepool/sourcesnap targetpool/targetsnap ...
 
 	if ( $targetsize < (64*1024*1024) ) {
-		print "			 NOTE: Target $targetfs dataset is < 64MB used - did you mistakenly run\n";
-		print "					 \`zfs create $args{'target'}\` on the target? ZFS initial\n";
-		print "					 replication must be to a NON EXISTENT DATASET, which will\n";
-		print "					 then be CREATED BY the initial replication process.\n\n";
+		print "          NOTE: Target $targetfs dataset is < 64MB used - did you mistakenly run\n";
+		print "                \`zfs create $args{'target'}\` on the target? ZFS initial\n";
+		print "                replication must be to a NON EXISTENT DATASET, which will\n";
+		print "                then be CREATED BY the initial replication process.\n\n";
 	}
 	return 0;
 }


### PR DESCRIPTION
Support poweruse use of things like "zfs send -Lce -p" and "zfs receive -o property=value -x property2" inside syncoid's great handing of resume, piping, etc.

I also converted spaces to tabs for internal consistency where appropriate.

Refer to #272 for discussion of an earlier version.