### PR TITLE
add pre, post and prune snapshot scripts

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -455,12 +455,35 @@ sub take_snapshots {
 
 	if ( (scalar(@newsnaps)) > 0) {
 		foreach my $snap ( @newsnaps ) {
+			my $dataset = (split '@', $snap)[0];
+			my $presnapshotfailure = 0;
+			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
+				$ENV{'SANOID_TARGET'} = $dataset;
+				if ($args{'verbose'}) { print "executing pre_snapshot_script '".$config{$dataset}{'pre_snapshot_script'}."' on dataset '$dataset'\n"; }
+				if (system($config{$dataset}{'pre_snapshot_script'}) != 0) {
+					warn "WARN: pre_snapshot_script failed, $?";
+					$config{$dataset}{'no_inconsistent_snapshot'} and next;
+					$presnapshotfailure = 1;
+				}
+				delete $ENV{'SANOID_TARGET'};
+			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
 				system($zfs, "snapshot", "$snap") == 0
 					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
 				# make sure we don't end up with multiple snapshots with the same ctime
 				sleep 1;
+			}
+			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
+				if (!$presnapshotfailure or $config{$dataset}{'force_post_snapshot_script'}) {
+					$ENV{'SANOID_TARGET'} = $dataset;
+					if ($args{'verbose'}) { print "executing post_snapshot_script '".$config{$dataset}{'post_snapshot_script'}."' on dataset '$dataset'\n"; }
+					if (system($config{$dataset}{'post_snapshot_script'}) != 0) {
+						warn "WARN: post_snapshot_script failed, $?";
+						$config{$dataset}{'no_inconsistent_snapshot'} and next;
+					}
+					delete $ENV{'SANOID_TARGET'};
+				}
 			}
 		}
 		$forcecacheupdate = 1;
@@ -661,7 +684,7 @@ sub init {
 	tie my %ini, 'Config::IniFiles', ( -file => $conf_file ) or die "FATAL: cannot load $conf_file - please create a valid local config file before running sanoid!";
 
 	# we'll use these later to normalize potentially true and false values on any toggle keys
-	my @toggles = ('autosnap','autoprune','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only');
+	my @toggles = ('autosnap','autoprune','monitor_dont_warn','monitor_dont_crit','monitor','recursive','process_children_only','no_inconsistent_snapshot','force_post_snapshot_script');
 	my @istrue=(1,"true","True","TRUE","yes","Yes","YES","on","On","ON");
 	my @isfalse=(0,"false","False","FALSE","no","No","NO","off","Off","OFF");
 

--- a/sanoid
+++ b/sanoid
@@ -456,9 +456,11 @@ sub take_snapshots {
 	if ( (scalar(@newsnaps)) > 0) {
 		foreach my $snap ( @newsnaps ) {
 			my $dataset = (split '@', $snap)[0];
+			my $snapname = (split '@', $snap)[1];
 			my $presnapshotfailure = 0;
 			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
 				$ENV{'SANOID_TARGET'} = $dataset;
+				$ENV{'SANOID_SNAPNAME'} = $snapname;
 				if ($args{'verbose'}) { print "executing pre_snapshot_script '".$config{$dataset}{'pre_snapshot_script'}."' on dataset '$dataset'\n"; }
 				if (system($config{$dataset}{'pre_snapshot_script'}) != 0) {
 					warn "WARN: pre_snapshot_script failed, $?";
@@ -466,6 +468,7 @@ sub take_snapshots {
 					$presnapshotfailure = 1;
 				}
 				delete $ENV{'SANOID_TARGET'};
+				delete $ENV{'SANOID_SNAPNAME'};
 			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
@@ -477,12 +480,14 @@ sub take_snapshots {
 			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
 				if (!$presnapshotfailure or $config{$dataset}{'force_post_snapshot_script'}) {
 					$ENV{'SANOID_TARGET'} = $dataset;
+					$ENV{'SANOID_SNAPNAME'} = $snapname;
 					if ($args{'verbose'}) { print "executing post_snapshot_script '".$config{$dataset}{'post_snapshot_script'}."' on dataset '$dataset'\n"; }
 					if (system($config{$dataset}{'post_snapshot_script'}) != 0) {
 						warn "WARN: post_snapshot_script failed, $?";
 						$config{$dataset}{'no_inconsistent_snapshot'} and next;
 					}
 					delete $ENV{'SANOID_TARGET'};
+					delete $ENV{'SANOID_SNAPNAME'};
 				}
 			}
 		}

--- a/sanoid
+++ b/sanoid
@@ -302,11 +302,12 @@ sub prune_snapshots {
 										my $dataset = (split '@', $snap)[0];
 										my $snapname = (split '@', $snap)[1];
 										if ($config{$dataset}{'pruning_script'}) {
+											my $timeout = 5;
 											$ENV{'SANOID_TARGET'} = $dataset;
 											$ENV{'SANOID_SNAPNAME'} = $snapname;
 											if ($args{'verbose'}) { print "executing pruning_script '".$config{$dataset}{'pruning_script'}."' on dataset '$dataset'\n"; }
-											system($config{$dataset}{'pruning_script'}) == 0
-												or warn "WARN: pruning_script failed, $?";
+											my $ret = runscript('pruning_script',$dataset,$timeout);
+
 											delete $ENV{'SANOID_TARGET'};
 											delete $ENV{'SANOID_SNAPNAME'};
 										}

--- a/sanoid
+++ b/sanoid
@@ -302,11 +302,10 @@ sub prune_snapshots {
 										my $dataset = (split '@', $snap)[0];
 										my $snapname = (split '@', $snap)[1];
 										if ($config{$dataset}{'pruning_script'}) {
-											my $timeout = 5;
 											$ENV{'SANOID_TARGET'} = $dataset;
 											$ENV{'SANOID_SNAPNAME'} = $snapname;
 											if ($args{'verbose'}) { print "executing pruning_script '".$config{$dataset}{'pruning_script'}."' on dataset '$dataset'\n"; }
-											my $ret = runscript('pruning_script',$dataset,$timeout);
+											my $ret = runscript('pruning_script',$dataset);
 
 											delete $ENV{'SANOID_TARGET'};
 											delete $ENV{'SANOID_SNAPNAME'};
@@ -475,7 +474,7 @@ sub take_snapshots {
 				$ENV{'SANOID_TARGET'} = $dataset;
 				$ENV{'SANOID_SNAPNAME'} = $snapname;
 				if ($args{'verbose'}) { print "executing pre_snapshot_script '".$config{$dataset}{'pre_snapshot_script'}."' on dataset '$dataset'\n"; }
-				my $ret = runscript('pre_snapshot_script',$dataset,$timeout);
+				my $ret = runscript('pre_snapshot_script',$dataset);
 
 				delete $ENV{'SANOID_TARGET'};
 				delete $ENV{'SANOID_SNAPNAME'};
@@ -498,7 +497,7 @@ sub take_snapshots {
 					$ENV{'SANOID_TARGET'} = $dataset;
 					$ENV{'SANOID_SNAPNAME'} = $snapname;
 					if ($args{'verbose'}) { print "executing post_snapshot_script '".$config{$dataset}{'post_snapshot_script'}."' on dataset '$dataset'\n"; }
-					runscript('post_snapshot_script',$dataset,$timeout);
+					runscript('post_snapshot_script',$dataset);
 
 					delete $ENV{'SANOID_TARGET'};
 					delete $ENV{'SANOID_SNAPNAME'};
@@ -1358,12 +1357,15 @@ sub removecachedsnapshots {
 sub runscript {
 	my $key=shift;
 	my $dataset=shift;
-	my $timeout=shift;
+
+	my $timeout=$config{$dataset}{'script_timeout'};
 
 	my $ret;
 	eval {
-		local $SIG{ALRM} = sub { die "alarm\n" };
-		alarm $timeout;
+		if ($timeout gt 0) {
+			local $SIG{ALRM} = sub { die "alarm\n" };
+			alarm $timeout;
+		}
 		$ret = system($config{$dataset}{$key});
 		alarm 0;
 	};

--- a/sanoid
+++ b/sanoid
@@ -458,17 +458,21 @@ sub take_snapshots {
 			my $dataset = (split '@', $snap)[0];
 			my $snapname = (split '@', $snap)[1];
 			my $presnapshotfailure = 0;
+			my $timeout = 5;
 			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
 				$ENV{'SANOID_TARGET'} = $dataset;
 				$ENV{'SANOID_SNAPNAME'} = $snapname;
 				if ($args{'verbose'}) { print "executing pre_snapshot_script '".$config{$dataset}{'pre_snapshot_script'}."' on dataset '$dataset'\n"; }
-				if (system($config{$dataset}{'pre_snapshot_script'}) != 0) {
-					warn "WARN: pre_snapshot_script failed, $?";
+				my $ret = runscript('pre_snapshot_script',$dataset,$timeout);
+
+				delete $ENV{'SANOID_TARGET'};
+				delete $ENV{'SANOID_SNAPNAME'};
+
+				if ($ret != 0) {
+					# warning was already thrown by runscript function
 					$config{$dataset}{'no_inconsistent_snapshot'} and next;
 					$presnapshotfailure = 1;
 				}
-				delete $ENV{'SANOID_TARGET'};
-				delete $ENV{'SANOID_SNAPNAME'};
 			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
@@ -482,10 +486,8 @@ sub take_snapshots {
 					$ENV{'SANOID_TARGET'} = $dataset;
 					$ENV{'SANOID_SNAPNAME'} = $snapname;
 					if ($args{'verbose'}) { print "executing post_snapshot_script '".$config{$dataset}{'post_snapshot_script'}."' on dataset '$dataset'\n"; }
-					if (system($config{$dataset}{'post_snapshot_script'}) != 0) {
-						warn "WARN: post_snapshot_script failed, $?";
-						$config{$dataset}{'no_inconsistent_snapshot'} and next;
-					}
+					runscript('post_snapshot_script',$dataset,$timeout);
+
 					delete $ENV{'SANOID_TARGET'};
 					delete $ENV{'SANOID_SNAPNAME'};
 				}
@@ -1335,6 +1337,38 @@ sub removecachedsnapshots {
 
 	# clear hash
 	undef %pruned;
+}
+
+#######################################################################################################################3
+#######################################################################################################################3
+#######################################################################################################################3
+
+sub runscript {
+	my $key=shift;
+	my $dataset=shift;
+	my $timeout=shift;
+
+	my $ret;
+	eval {
+		local $SIG{ALRM} = sub { die "alarm\n" };
+		alarm $timeout;
+		$ret = system($config{$dataset}{$key});
+		alarm 0;
+	};
+	if ($@) {
+		if ($@ eq "alarm\n") {
+			warn "WARN: $key didn't finish in the allowed time!";
+		} else {
+			warn "CRITICAL ERROR: $@";
+		}
+		return -1;
+	} else {
+		if ($ret != 0) {
+			warn "WARN: $key failed, $?";
+		}
+	}
+
+	return $ret;
 }
 
 __END__

--- a/sanoid
+++ b/sanoid
@@ -469,7 +469,6 @@ sub take_snapshots {
 			my $dataset = (split '@', $snap)[0];
 			my $snapname = (split '@', $snap)[1];
 			my $presnapshotfailure = 0;
-			my $timeout = 5;
 			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
 				$ENV{'SANOID_TARGET'} = $dataset;
 				$ENV{'SANOID_SNAPNAME'} = $snapname;

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -67,6 +67,17 @@
 	daily_warn = 48
 	daily_crit = 60
 
+[template_scripts]
+	### run script before snapshot
+	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	pre_snapshot_script = /path/to/script.sh
+	### run script after snapshot
+	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	post_snapshot_script = /path/to/script.sh
+	### don't take an inconsistent snapshot
+	#no_inconsistent_snapshot = yes
+	### run post_snapshot_script when pre_snapshot_script is failing
+	#force_post_snapshot_script = yes
 
 [template_ignore]
 	autoprune = no

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -74,12 +74,14 @@
 	### run script after snapshot
 	### dataset name will be supplied as an environment variable $SANOID_TARGET
 	post_snapshot_script = /path/to/script.sh
+	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	pruning_script = /path/to/script.sh
 	### don't take an inconsistent snapshot
 	#no_inconsistent_snapshot = yes
 	### run post_snapshot_script when pre_snapshot_script is failing
 	#force_post_snapshot_script = yes
-	### dataset name will be supplied as an environment variable $SANOID_TARGET
-	pruning_script = /path/to/script.sh
+	### limit allowed execution time of scripts before continuing (<= 0 -> infinite)
+	script_timeout = 5
 
 [template_ignore]
 	autoprune = no

--- a/sanoid.conf
+++ b/sanoid.conf
@@ -68,19 +68,19 @@
 	daily_crit = 60
 
 [template_scripts]
+	### dataset and snapshot name will be supplied as environment variables
+	### for all pre/post/prune scripts ($SANOID_TARGET, $SANOID_SNAPNAME)
 	### run script before snapshot
-	### dataset name will be supplied as an environment variable $SANOID_TARGET
 	pre_snapshot_script = /path/to/script.sh
 	### run script after snapshot
-	### dataset name will be supplied as an environment variable $SANOID_TARGET
 	post_snapshot_script = /path/to/script.sh
-	### dataset name will be supplied as an environment variable $SANOID_TARGET
+	### run script after pruning snapshot
 	pruning_script = /path/to/script.sh
-	### don't take an inconsistent snapshot
+	### don't take an inconsistent snapshot (skip if pre script fails)
 	#no_inconsistent_snapshot = yes
 	### run post_snapshot_script when pre_snapshot_script is failing
 	#force_post_snapshot_script = yes
-	### limit allowed execution time of scripts before continuing (<= 0 -> infinite)
+	### limit allowed execution time of scripts before continuing (<= 0: infinite)
 	script_timeout = 5
 
 [template_ignore]

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -15,6 +15,10 @@ path =
 recursive =
 use_template =
 process_children_only =
+pre_snapshot_script =
+post_snapshot_script =
+no_inconsistent_snapshot =
+force_post_snapshot_script =
 
 # If any snapshot type is set to 0, we will not take snapshots for it - and will immediately
 # prune any of those type snapshots already present.

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -17,9 +17,10 @@ use_template =
 process_children_only =
 pre_snapshot_script =
 post_snapshot_script =
+pruning_script =
+script_timeout = 5
 no_inconsistent_snapshot =
 force_post_snapshot_script =
-pruning_script =
 
 # If any snapshot type is set to 0, we will not take snapshots for it - and will immediately
 # prune any of those type snapshots already present.


### PR DESCRIPTION
implements pre/post script execution for snapshot creation. This replaces the PR #193 which was cherry picked, this pr adds:

- commit from @darkbasic for providing the snapshot name to the scripts
- timeout logic for the scripts so the can't hang sanoid forever
- cleanup of environment in any script error case

I still need to restructure the code a bit, make the timeout configurable and add documentation.

Fixes #105 