### PR TITLE
removed sleeping between snapshot taking

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -459,8 +459,6 @@ sub take_snapshots {
 			if (!$args{'readonly'}) {
 				system($zfs, "snapshot", "$snap") == 0
 					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
-				# make sure we don't end up with multiple snapshots with the same ctime
-				sleep 1;
 			}
 		}
 		$forcecacheupdate = 1;


### PR DESCRIPTION
For me sanoid runtime is down by 1/3 with a small count of datasets and the difference will only get larger for a higher dataset count.
I don't see any problem if there are snapshots with the same creation time, in the typical use case the snapshots grouped by interval type won't have the same creation time and even if the will get the same creation time anyhow it shouldn't break anything.
But maybe I overlooked something, I will run this on several machines and check if anything comes up.