### PR TITLE
split snapshot taking/pruning into seperate units for debian package …

### DIFF
--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -16,4 +16,14 @@ override_dh_auto_install:
 	@mkdir -p $(DESTDIR)/usr/share/doc/sanoid; \
 		cp sanoid.conf $(DESTDIR)/usr/share/doc/sanoid/sanoid.conf.example;
 	@mkdir -p $(DESTDIR)/lib/systemd/system; \
-		cp debian/sanoid.timer $(DESTDIR)/lib/systemd/system;
+		cp debian/sanoid-prune.service $(DESTDIR)/lib/systemd/system;
+
+override_dh_installinit:
+	dh_installinit --noscripts
+
+override_dh_systemd_enable:
+	dh_systemd_enable sanoid.timer
+	dh_systemd_enable sanoid-prune.service
+
+override_dh_systemd_start:
+	dh_systemd_start sanoid.timer

--- a/packages/debian/sanoid-prune.service
+++ b/packages/debian/sanoid-prune.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Cleanup ZFS Pool
+Requires=zfs.target
+After=zfs.target sanoid.service
+ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
+
+[Service]
+Environment=TZ=UTC
+Type=oneshot
+ExecStart=/usr/sbin/sanoid --prune-snapshots
+
+[Install]
+WantedBy=sanoid.service

--- a/packages/debian/sanoid.service
+++ b/packages/debian/sanoid.service
@@ -7,4 +7,4 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/sbin/sanoid --cron
+ExecStart=/usr/sbin/sanoid --take-snapshots


### PR DESCRIPTION
…to prevent pruning blocking snapshot taking if the later takes long time.

It happened to me on some occasions that the snapshot pruning blocked the taking, so it's better to do the pruning separately:

- i forgot the pruning configuration, ended up with ~100 000 datasets. After adding the correct pruning options, sanoid naturally ran a long time for pruning but a lot of snapshots were missed to be taken
- Received a huge amount of snapshots with a zfs received, which were pruned by sanoid delaying snapshot taking.