### PR TITLE
Add dependecy for the configini package

### DIFF
--- a/packages/rhel/sanoid.spec
+++ b/packages/rhel/sanoid.spec
@@ -14,7 +14,7 @@ License:	   GPLv3
 URL:		   https://github.com/jimsalterjrs/sanoid
 Source0:           https://github.com/jimsalterjrs/%{name}/archive/%{git_tag}/%{name}-%{version}.tar.gz
 
-Requires:	   perl, mbuffer, lzop, pv
+Requires:	   perl, mbuffer, lzop, pv, perl-Config-IniFiles
 %if 0%{?_with_systemd}
 Requires:      systemd >= 212
 


### PR DESCRIPTION
Adds a Requires for the perl-Config-IniFiles to the spec file so it will be installed, otherwise sanoid will fail at runtime.