### PR TITLE
Revert "Zfs Recursion"

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -502,13 +502,7 @@ sub take_snapshots {
 					# update to most current possible datestamp
 					%datestamp = get_date();
 					# print "we should have had a $type snapshot of $path $maxage seconds ago; most recent is $newestage seconds old.\n";
-
-					# use zfs (atomic) recursion if specified in config
-					if ($config{$section}{'zfs_recursion'}) {
-						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type\@");
-					} else {
-						push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type");
-					}
+					push(@newsnaps, "$path\@autosnap_$datestamp{'sortable'}${dateSuffix}_$type");
 				}
 			}
 		}
@@ -516,14 +510,8 @@ sub take_snapshots {
 
 	if ( (scalar(@newsnaps)) > 0) {
 		foreach my $snap ( @newsnaps ) {
-			my @split = split '@', $snap, -1;
-			my $recursiveFlag = 0;
-			if (scalar(@split) == 3) {
-				$recursiveFlag = 1;
-				chop $snap;
-			}
-			my $dataset = $split[0];
-			my $snapname = $split[1];
+			my $dataset = (split '@', $snap)[0];
+			my $snapname = (split '@', $snap)[1];
 			my $presnapshotfailure = 0;
 			if ($config{$dataset}{'pre_snapshot_script'} and !$args{'readonly'}) {
 				$ENV{'SANOID_TARGET'} = $dataset;
@@ -542,13 +530,8 @@ sub take_snapshots {
 			}
 			if ($args{'verbose'}) { print "taking snapshot $snap\n"; }
 			if (!$args{'readonly'}) {
-				if ($recursiveFlag) {
-					system($zfs, "snapshot", "-r", "$snap") == 0
-						or warn "CRITICAL ERROR: $zfs snapshot -r $snap failed, $?";
-				} else {
-					system($zfs, "snapshot", "$snap") == 0
-						or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
-				}
+				system($zfs, "snapshot", "$snap") == 0
+					or warn "CRITICAL ERROR: $zfs snapshot $snap failed, $?";
 			}
 			if ($config{$dataset}{'post_snapshot_script'} and !$args{'readonly'}) {
 				if (!$presnapshotfailure or $config{$dataset}{'force_post_snapshot_script'}) {
@@ -863,9 +846,7 @@ sub init {
 		my $recursive = $ini{$section}{'recursive'} && grep( /^$ini{$section}{'recursive'}$/, @istrue );
 		my $skipChildren = $ini{$section}{'skip_children'} && grep( /^$ini{$section}{'skip_children'}$/, @istrue );
 		my @datasets;
-		if ($ini{$section}{'recursive'} =~ /zfs/i) {
-			$config{$section}{'zfs_recursion'} = 1;
-		} elsif ($recursive || $skipChildren) {
+		if ($recursive || $skipChildren) {
 			@datasets = getchilddatasets($config{$section}{'path'});
 			DATASETS: foreach my $dataset(@datasets) {
 				chomp $dataset;


### PR DESCRIPTION
Reverts jimsalterjrs/sanoid#181

Feature changes `recursive` from a toggle (boolean) argument as processed in `init()` to a three-states-possible argument.

In its current condition, datasets without `recursive` set at all cause a failure due to use of uninitialized value in the regex on line 866.