### PR TITLE
Fix systemd service definitions.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ Create a systemd service:
 ```bash
 cat << "EOF" | sudo tee /etc/systemd/system/sanoid.service
 [Unit]
-Description=Snapshot ZFS Pool
+Description=Sanoid ZFS Snapshot Manager
 Requires=zfs.target
 After=zfs.target
 ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
@@ -83,23 +83,7 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/local/sbin/sanoid --take-snapshots
-EOF
-
-cat << "EOF" | sudo tee /etc/systemd/system/sanoid-prune.service
-[Unit]
-Description=Cleanup ZFS Pool
-Requires=zfs.target
-After=zfs.target sanoid.service
-ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
-
-[Service]
-Environment=TZ=UTC
-Type=oneshot
-ExecStart=/usr/local/sbin/sanoid --prune-snapshots
-
-[Install]
-WantedBy=sanoid.service
+ExecStart=/usr/local/sbin/sanoid --cron --verbose
 EOF
 ```
 


### PR DESCRIPTION
`sanoid-prune.service` is not referenced by a timer, so I have removed it.

I also modified the behavior of sanoid.service so it will take and prune snapshots according to the config file:
 - `--cron` switch is required for it to take action as a service
 - `--verbose` is there so that useful logs appear under `journalctl -t sanoid` (I personally run `--debug`)