### PR TITLE
Revert #365

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/local/sbin/sanoid --take-snapshots
+ExecStart=/usr/local/sbin/sanoid --take-snapshots --verbose
 EOF
 
 cat << "EOF" | sudo tee /etc/systemd/system/sanoid-prune.service
@@ -96,7 +96,7 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/local/sbin/sanoid --prune-snapshots
+ExecStart=/usr/local/sbin/sanoid --prune-snapshots --verbose
 
 [Install]
 WantedBy=sanoid.service

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ Create a systemd service:
 ```bash
 cat << "EOF" | sudo tee /etc/systemd/system/sanoid.service
 [Unit]
-Description=Sanoid ZFS Snapshot Manager
+Description=Snapshot ZFS Pool
 Requires=zfs.target
 After=zfs.target
 ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
@@ -83,7 +83,23 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/local/sbin/sanoid --cron --verbose
+ExecStart=/usr/local/sbin/sanoid --take-snapshots
+EOF
+
+cat << "EOF" | sudo tee /etc/systemd/system/sanoid-prune.service
+[Unit]
+Description=Cleanup ZFS Pool
+Requires=zfs.target
+After=zfs.target sanoid.service
+ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
+
+[Service]
+Environment=TZ=UTC
+Type=oneshot
+ExecStart=/usr/local/sbin/sanoid --prune-snapshots
+
+[Install]
+WantedBy=sanoid.service
 EOF
 ```
 


### PR DESCRIPTION
This PR reverts #365 which removed the sanoid-prune.service from the install instruction.
@danielewood It is not referenced by a timer but it's referenced by the main sanoid.service and is run afterwards. For an explanation why this is a better approach see this PR #287.

I kept the --verbose flag as it's useful for journald logging.