### PR TITLE
Added line to enable sanoid-prune.service

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,6 +125,8 @@ Reload systemd and start our timer:
 ```bash
 # Tell systemd about our new service definitions
 sudo systemctl daemon-reload
+# Enable sanoid-prune.service to allow it to be triggered by sanoid.service
+sudo systemctl enable sanoid-prune.service
 # Enable and start the Sanoid timer
 sudo systemctl enable sanoid.timer
 sudo systemctl start sanoid.timer


### PR DESCRIPTION
@phreaker0,
I found that on my systems(CentOS7), sanoid-pune.service did nothing until I enabled it. Once I did that, it was called by sanoid.service.

References #367 