### PR TITLE
Dont force TZ=UTC for sys-fs/sanoid cron on gentoo

### DIFF
--- a/packages/gentoo/sys-fs/sanoid/files/sanoid.cron
+++ b/packages/gentoo/sys-fs/sanoid/files/sanoid.cron
@@ -1,1 +1,1 @@
-* * * * * root TZ=UTC /usr/bin/sanoid --cron
+* * * * * root /usr/bin/sanoid --cron


### PR DESCRIPTION
Removing TZ=UTC from cron for the gentoo build as thats causing some timezone confusion for some folks.