### PR TITLE
Declare that sanoid service 'Wants' sanoid-prune

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,6 +78,8 @@ cat << "EOF" | sudo tee /etc/systemd/system/sanoid.service
 Description=Snapshot ZFS Pool
 Requires=zfs.target
 After=zfs.target
+Wants=sanoid-prune.service
+Before=sanoid-prune.service
 ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 
 [Service]

--- a/packages/debian/sanoid-prune.service
+++ b/packages/debian/sanoid-prune.service
@@ -7,7 +7,7 @@ ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/sbin/sanoid --prune-snapshots
+ExecStart=/usr/sbin/sanoid --prune-snapshots --verbose
 
 [Install]
 WantedBy=sanoid.service

--- a/packages/debian/sanoid.service
+++ b/packages/debian/sanoid.service
@@ -2,9 +2,11 @@
 Description=Snapshot ZFS Pool
 Requires=zfs.target
 After=zfs.target
+Wants=sanoid-prune.service
+Before=sanoid-prune.service
 ConditionFileNotEmpty=/etc/sanoid/sanoid.conf
 
 [Service]
 Environment=TZ=UTC
 Type=oneshot
-ExecStart=/usr/sbin/sanoid --take-snapshots
+ExecStart=/usr/sbin/sanoid --take-snapshots --verbose


### PR DESCRIPTION
The `sanoid-prune.service` never runs after `sanoid.service`.

Declare a `Wants` dependency, and `Before` condition on `sanoid-prune.service` in the sanoid unit, and prune is run after 'sanoid.service'.

The `WantedBy` condition currently in the `sanoid-prune.service` unit will not apply to oneshot units in the way required because conditions in the install section are only applied upon enable/disable.

From [systemd.unit](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BInstall%5D%20Section%20Options) `[Install]` Section Options
> Unit files may include an "[Install]" section, which carries installation information for the unit. This section is not interpreted by systemd(1) during runtime; it is used by the enable and disable commands of the systemctl(1) tool during installation of a unit.

---

Also add --verbose flag for logging to journald, as mentioned in readme.