### PR TITLE
Gracefully handle error when source dataset disappeared

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1174,7 +1174,6 @@ sub dataset_exists {
 	close $fh;
 
 	if ($result =~ /dataset does not exist/) {
-		warn "$fsescaped does not exist...\n";
 		return 0;
 	}
 

--- a/syncoid
+++ b/syncoid
@@ -290,7 +290,10 @@ sub syncdataset {
 
 	if (!defined $sync) {
 		# zfs already printed the corresponding error
-		if ($exitcode < 2) { $exitcode = 2; }
+		if (dataset_exists($sourcehost, $sourcefs, $sourceisroot) and $exitcode < 2) {
+			$exitcode = 2;
+		}
+
 		return 0;
 	}
 
@@ -1145,6 +1148,37 @@ sub getzfsvalue {
 	my @values = split(/\t/,$value);
 	$value = $values[2];
 	return $value;
+}
+
+sub dataset_exists {
+	my ($rhost, $fs, $isroot) = @_;
+
+	my $fsescaped = escapeshellparam($fs);
+
+	my $mysudocmd;
+	if ($isroot) {
+		$mysudocmd = '';
+	}
+	else {
+		$mysudocmd = $sudocmd;
+	}
+
+	my $command = "$rhost $mysudocmd $zfscmd get -H creation $fsescaped";
+
+	if ($debug) {
+		print "$command\n";
+	}
+
+	open my $fh, '-|', "$command 2>&1";
+	my $result = <$fh>;
+	close $fh;
+
+	if ($result =~ /dataset does not exist/) {
+		warn "$fsescaped does not exist...\n";
+		return 0;
+	}
+
+	return 1;
 }
 
 sub readablebytes {

--- a/syncoid
+++ b/syncoid
@@ -286,12 +286,18 @@ sub syncdataset {
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
-	my $sync = getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync');
+	my ($sync, $error) = getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'syncoid:sync');
 
 	if (!defined $sync) {
 		# zfs already printed the corresponding error
-		if (dataset_exists($sourcehost, $sourcefs, $sourceisroot) and $exitcode < 2) {
-			$exitcode = 2;
+		if ($error =~ /\bdataset does not exist\b/) {
+			if (!$quiet) { print "WARN Skipping dataset (dataset no longer exists): $sourcefs...\n"; }
+			return 0;
+		}
+		else {
+			# print the error out and set exit code
+			print "ERROR: $error\n";
+			if ($exitcode < 2) { $exitcode = 2 }
 		}
 
 		return 0;
@@ -1137,47 +1143,22 @@ sub getzfsvalue {
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 	if ($debug) { print "$rhost $mysudocmd $zfscmd get -H $property $fsescaped\n"; }
-	open FH, "$rhost $mysudocmd $zfscmd get -H $property $fsescaped |";
-	my $value = <FH>;
-	close FH;
-
-	if (!defined $value) {
-		return undef;
-	}
+	my ($value, $error, $exit) = capture {
+		system("$rhost $mysudocmd $zfscmd get -H $property $fsescaped");
+	};
 
 	my @values = split(/\t/,$value);
 	$value = $values[2];
-	return $value;
-}
 
-sub dataset_exists {
-	my ($rhost, $fs, $isroot) = @_;
+	my $wantarray = wantarray || 0;
 
-	my $fsescaped = escapeshellparam($fs);
-
-	my $mysudocmd;
-	if ($isroot) {
-		$mysudocmd = '';
-	}
-	else {
-		$mysudocmd = $sudocmd;
+	# If we are in scalar context and there is an error, print it out.
+	# Otherwise we assume the caller will deal with it.
+	if (!$wantarray and $error) {
+		print "ERROR getzfsvalue $fs $property: $error\n";
 	}
 
-	my $command = "$rhost $mysudocmd $zfscmd get -H creation $fsescaped";
-
-	if ($debug) {
-		print "$command\n";
-	}
-
-	open my $fh, '-|', "$command 2>&1";
-	my $result = <$fh>;
-	close $fh;
-
-	if ($result =~ /dataset does not exist/) {
-		return 0;
-	}
-
-	return 1;
+	return $wantarray ? ($value, $error) : $value;
 }
 
 sub readablebytes {


### PR DESCRIPTION
If the source dataset dissappeared before we were able to get the
sanoid:sync property, do not set an error exit code.  Handle this
gracefully as this should not be considered an error.

Fixes #380