### PR TITLE
Documentation buglet, --sshkey specifies the *key*

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1799,7 +1799,7 @@ Options:
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times
   --sendoptions=OPTIONS Use advanced options for zfs send (the arguments are filterd as needed), e.g. syncoid --sendoptions="Lc e" sets zfs send -L -c -e ...
   --recvoptions=OPTIONS Use advanced options for zfs receive (the arguments are filterd as needed), e.g. syncoid --recvoptions="ux recordsize o compression=lz4" sets zfs receive -u -x recordsize -o compression=lz4 ...
-  --sshkey=FILE         Specifies a ssh public key to use to connect
+  --sshkey=FILE         Specifies a ssh key to use to connect
   --sshport=PORT        Connects to remote on a particular port
   --sshcipher|c=CIPHER  Passes CIPHER to ssh to use a particular cipher set
   --sshoption|o=OPTION  Passes OPTION to ssh for remote usage. Can be specified multiple times


### PR DESCRIPTION
The `--sshkey` option specifies the ssh key, *not* the ssh public key.  Empirically, it fails if you point it at a public key and works if you point it at the private part.  Make sense since it's being used as the arg to `-i` in the `ssh` command line.