### PR TITLE
WIP: Convert syncoid to use DateTime ISO output

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -14,6 +14,7 @@ use Pod::Usage;
 use Time::Local;
 use Sys::Hostname;
 use Capture::Tiny ':all';
+use DateTime;
 
 my $mbuffer_size = "16M";
 
@@ -1368,8 +1369,8 @@ sub newsyncsnap {
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 	my $hostid = hostname();
-	my %date = getdate();
-	my $snapname = "syncoid\_$identifier$hostid\_$date{'stamp'}";
+	my $datestamp = DateTime->now()->iso8601();
+	my $snapname = "syncoid\_$identifier$hostid\_$datestamp";
 	my $snapcmd = "$rhost $mysudocmd $zfscmd snapshot $fsescaped\@$snapname\n";
 	if ($debug) { print "DEBUG: creating sync snapshot using \"$snapcmd\"...\n"; }
 	system($snapcmd) == 0 or do {
@@ -1638,21 +1639,6 @@ sub getsendsize {
 		$sendsize = 4096;
 	}
 	return $sendsize;
-}
-
-sub getdate {
-	my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
-	$year += 1900;
-	my %date;
-	$date{'unix'} = (((((((($year - 1971) * 365) + $yday) * 24) + $hour) * 60) + $min) * 60) + $sec;
-	$date{'year'} = $year;
-	$date{'sec'} = sprintf ("%02u", $sec);
-	$date{'min'} = sprintf ("%02u", $min);
-	$date{'hour'} = sprintf ("%02u", $hour);
-	$date{'mday'} = sprintf ("%02u", $mday);
-	$date{'mon'} = sprintf ("%02u", ($mon + 1));
-	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}:$date{'hour'}:$date{'min'}:$date{'sec'}";
-	return %date;
 }
 
 sub escapeshellparam {


### PR DESCRIPTION
Example for #409, do away with the complicated math to generate the date format use DateTime->now->iso8610 formatting.

Needs updates to INSTALL document to specify additional packages to install.