### PR TITLE
Update syncoid version to v2.0.2 also...

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -4,7 +4,7 @@
 # from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this
 # project's Git repository at https://github.com/jimsalterjrs/sanoid/blob/master/LICENSE.
 
-$::VERSION = '2.0.0';
+$::VERSION = '2.0.2';
 
 use strict;
 use warnings;


### PR DESCRIPTION
Turns out there is a version in `syncoid` that was missed too. These should probably just pull from the VERSION file some how?