### PR TITLE
improve dataset detection by only including mounted datasets

### DIFF
--- a/findoid
+++ b/findoid
@@ -102,14 +102,19 @@ sub getdataset {
 
 	my ($path) = @_;
 
-	open FH, "$zfs list -Ho mountpoint |";
+	open FH, "$zfs list -H -t filesystem -o mountpoint,mounted |";
 	my @datasets = <FH>;
 	close FH;
 
 	my @matchingdatasets;
 	foreach my $dataset (@datasets) {
 		chomp $dataset;
-		if ( $path =~ /^$dataset/ ) { push @matchingdatasets, $dataset; }
+		my ($mountpoint, $mounted) = ($dataset =~ m/([^\t]*)\t*(.*)/);
+		if ($mounted ne "yes") {
+			next;
+		}
+
+		if ( $path =~ /^$mountpoint/ ) { push @matchingdatasets, $mountpoint; }
 	}
 
 	my $bestmatch = '';


### PR DESCRIPTION
This solves issues when having intermediate datasets for organisation purposes which aren't mounted.