### PR TITLE
handle FileNotFound errors properly

### DIFF
--- a/findoid
+++ b/findoid
@@ -64,6 +64,10 @@ sub getversions {
 		my $filename = "$dataset/$snappath/$snap/$relpath";
 		my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size,$atime,$mtime,$ctime,$blksize,$blocks) = stat($filename);
 
+		if (!defined $size) {
+			next;
+		}
+
 		# only push to the $versions hash if this size and mtime aren't already present (simple dedupe)
 		my $duplicate = 0;
 		foreach my $version (keys %versions) {


### PR DESCRIPTION
currently if the requested file doesn't exist in an snapshot a lot of perl errors will end up in the output. This patch handles the error properly.