### PR TITLE
Move sanoid cache and lock files to subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 	Specify a location for the config file named sanoid.conf. Defaults to /etc/sanoid
 
++ --cache-dir
+
+	Specify a directory to store the zfs snapshot cache. Defaults to /var/cache/sanoid
+
 + --take-snapshots
 
 	This will process your sanoid.conf file, create snapshots, but it will NOT purge expired ones. (Note that snapshots taken are atomic in an individual dataset context, <i>not</i> a global context - snapshots of pool/dataset1 and pool/dataset2 will each be internally consistent and atomic, but one may be a few filesystem transactions "newer" than the other.)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Which would be enough to tell sanoid to take and keep 36 hourly snapshots, 30 da
 
 	Specify a directory to store the zfs snapshot cache. Defaults to /var/cache/sanoid
 
++ --run-dir
+
+	Specify a directory for temporary files such as lock files. Defaults to /var/run/sanoid
+
 + --take-snapshots
 
 	This will process your sanoid.conf file, create snapshots, but it will NOT purge expired ones. (Note that snapshots taken are atomic in an individual dataset context, <i>not</i> a global context - snapshots of pool/dataset1 and pool/dataset2 will each be internally consistent and atomic, but one may be a few filesystem transactions "newer" than the other.)

--- a/sanoid
+++ b/sanoid
@@ -19,10 +19,11 @@ use Capture::Tiny ':all';
 
 my %args = (
 	"configdir" => "/etc/sanoid",
-	"cache-dir" => "/var/cache/sanoid"
+	"cache-dir" => "/var/cache/sanoid",
+	"run-dir" => "/var/run/sanoid"
 );
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
-                   "configdir=s", "cache-dir=s",
+                   "configdir=s", "cache-dir=s", "run-dir=s",
                    "monitor-health", "force-update",
                    "monitor-snapshots", "take-snapshots", "prune-snapshots", "force-prune",
                    "monitor-capacity"
@@ -46,8 +47,10 @@ my $default_conf_file = "$args{'configdir'}/sanoid.defaults.conf";
 my %config = init($conf_file,$default_conf_file);
 
 my $cache_dir = $args{'cache-dir'};
+my $run_dir = $args{'run-dir'};
 
 make_path($cache_dir);
+make_path($run_dir);
 
 # if we call getsnaps(%config,1) it will forcibly update the cache, TTL or no TTL
 my $forcecacheupdate = 0;
@@ -1373,10 +1376,10 @@ sub get_zpool_capacity {
 sub checklock {
 	# take argument $lockname.
 	#
-	# read /var/run/$lockname.lock for a pid on first line and a mutex on second line.
+	# read $run_dir/$lockname.lock for a pid on first line and a mutex on second line.
 	#
-	# check process list to see if the pid from /var/run/$lockname.lock is still active with
-	# the original mutex found in /var/run/$lockname.lock.
+	# check process list to see if the pid from $run_dir/$lockname.lock is still active with
+	# the original mutex found in $run_dir/$lockname.lock.
 	#
 	# return:
 	#    0 if lock is present and valid for another process
@@ -1388,7 +1391,7 @@ sub checklock {
 	#
 
 	my $lockname = shift;
-	my $lockfile = "/var/run/$lockname.lock";
+	my $lockfile = "$run_dir/$lockname.lock";
 
 	if (! -e $lockfile) {
 		# no lockfile
@@ -1441,11 +1444,11 @@ sub checklock {
 sub removelock {
 	# take argument $lockname.
 	#
-	# make sure /var/run/$lockname.lock actually belongs to me (contains my pid and mutex)
+	# make sure $run_dir/$lockname.lock actually belongs to me (contains my pid and mutex)
 	# and remove it if it does, die if it doesn't.
 
 	my $lockname = shift;
-	my $lockfile = "/var/run/$lockname.lock";
+	my $lockfile = "$run_dir/$lockname.lock";
 
 	if (checklock($lockname) == 2) {
 		unlink $lockfile;
@@ -1460,11 +1463,11 @@ sub removelock {
 sub writelock {
 	# take argument $lockname.
 	#
-	# write a lockfile to /var/run/$lockname.lock with first line
+	# write a lockfile to $run_dir/$lockname.lock with first line
 	# being my pid and second line being my mutex.
 
 	my $lockname = shift;
-	my $lockfile = "/var/run/$lockname.lock";
+	my $lockfile = "$run_dir/$lockname.lock";
 
 	# die honorably rather than overwriting a valid, existing lock
 	if (! checklock($lockname)) {
@@ -1668,6 +1671,7 @@ Options:
 
   --configdir=DIR       Specify a directory to find config file sanoid.conf
   --cache-dir=DIR       Specify a directory to store the zfs snapshot cache
+  --run-dir=DIR         Specify a directory for temporary files such as lock files
 
   --cron                Creates snapshots and purges expired snapshots
   --verbose             Prints out additional information during a sanoid run

--- a/sanoid
+++ b/sanoid
@@ -11,15 +11,19 @@ use strict;
 use warnings;
 use Config::IniFiles; # read samba-style conf file
 use Data::Dumper;     # debugging - print contents of hash
-use File::Path;       # for rmtree command in use_prune
+use File::Path 'make_path';
 use Getopt::Long qw(:config auto_version auto_help);
 use Pod::Usage;       # pod2usage
 use Time::Local;      # to parse dates in reverse
 use Capture::Tiny ':all';
 
-my %args = ("configdir" => "/etc/sanoid");
+my %args = (
+	"configdir" => "/etc/sanoid",
+	"cache-dir" => "/var/cache/sanoid"
+);
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
-                   "monitor-health", "force-update", "configdir=s",
+                   "configdir=s", "cache-dir=s",
+                   "monitor-health", "force-update",
                    "monitor-snapshots", "take-snapshots", "prune-snapshots", "force-prune",
                    "monitor-capacity"
           ) or pod2usage(2);
@@ -41,9 +45,13 @@ my $default_conf_file = "$args{'configdir'}/sanoid.defaults.conf";
 # parse config file
 my %config = init($conf_file,$default_conf_file);
 
+my $cache_dir = $args{'cache-dir'};
+
+make_path($cache_dir);
+
 # if we call getsnaps(%config,1) it will forcibly update the cache, TTL or no TTL
 my $forcecacheupdate = 0;
-my $cache = '/var/cache/sanoidsnapshots.txt';
+my $cache = "$cache_dir/snapshots.txt";
 my $cacheTTL = 900; # 15 minutes
 my %snaps = getsnaps( \%config, $cacheTTL, $forcecacheupdate );
 my %pruned;
@@ -1659,6 +1667,7 @@ Assumes --cron --verbose if no other arguments (other than configdir) are specif
 Options:
 
   --configdir=DIR       Specify a directory to find config file sanoid.conf
+  --cache-dir=DIR       Specify a directory to store the zfs snapshot cache
 
   --cron                Creates snapshots and purges expired snapshots
   --verbose             Prints out additional information during a sanoid run


### PR DESCRIPTION
I would like to run sanoid as an unprivileged user using ZFS privilege delegation. This works fine, except sanoid tries to write files directly into `/var/cache` and `/var/run`, which can only be written to by root.

I would like to place sanoid's files in subdirectories, ie. `/var/cache/sanoid` and `/var/run/sanoid`, which will allow me to use systemd's `CacheDirectory` and `RuntimeDirectory` options to create those folders with the correct permissions.

Rather than just changing the hardcoded directories, I decided to add `--cache-dir` and `--run-dir` options that allow the directories to be specified. I defaulted them to `/var/cache/sanoid` and `/var/run/sanoid`, but they could default to `/var/cache` and `/var/run` if there are backwards compatibility concerns I didn't think of.