### PR TITLE
Revert "Depend on systemd"

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -12,7 +12,6 @@ Package: sanoid
 Architecture: all
 Depends: libcapture-tiny-perl,
          libconfig-inifiles-perl,
-         systemd,
          zfsutils-linux | zfs,
          ${misc:Depends},
          ${perl:Depends}


### PR DESCRIPTION
The debian package ships with a systemd timer unit but can still be usefull on systems without systemd

This reverts commit 59e181e61d2e0d9f29834fc65b2201f75d1490a4.

Fixes #469