### PR TITLE
Fixed Typo in arguments.

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1470,7 +1470,7 @@ sub getsnaps() {
 		$fsescaped = escapeshellparam($fsescaped);
 	}
 
-	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get A-Hpd 1 -t snapshot guid,creation $fsescaped";
+	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t snapshot guid,creation $fsescaped";
 	if ($debug) {
 		$getsnapcmd = "$getsnapcmd |";
 		print "DEBUG: getting list of snapshots on $fs using $getsnapcmd...\n";


### PR DESCRIPTION
Removed errant A in zfs list command line arguments.

Fixes #480 