### PR TITLE
post install script for debian package to remove old unused snapshot …

### DIFF
--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove old cache file
+[ -f /var/cache/sanoidsnapshots.txt ] && rm /var/cache/sanoidsnapshots.txt


### PR DESCRIPTION
…cache file

(Was deprecated by #463)

I tested this on a ubuntu 18.04 system and the package upgrade removed the old cache file as intended.