### PR TITLE
fix debian postinst in the case of non existing legacy cache file

### DIFF
--- a/packages/debian/postinst
+++ b/packages/debian/postinst
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # remove old cache file
-[ -f /var/cache/sanoidsnapshots.txt ] && rm /var/cache/sanoidsnapshots.txt
+[ -f /var/cache/sanoidsnapshots.txt ] && rm /var/cache/sanoidsnapshots.txt || true


### PR DESCRIPTION
Fixes #489 