### PR TITLE
sync snap timestamp format

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1758,7 +1758,7 @@ sub getdate {
 	$date{'hour'} = sprintf ("%02u", $hour);
 	$date{'mday'} = sprintf ("%02u", $mday);
 	$date{'mon'} = sprintf ("%02u", ($mon + 1));
-	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}:$date{'hour'}:$date{'min'}:$date{'sec'}";
+	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}_$date{'hour'}:$date{'min'}:$date{'sec'}";
 	return %date;
 }
 


### PR DESCRIPTION
Change the sync snap timestamp format to `YYYY-MM-DD_HH:MM:SS`.

Previously it was `YYYY-MM-DD:HH:MM:SS`. Note the confusing `:` between the date and the time :)