### PR TITLE
fix stream sync from bookmark

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1664,7 +1664,7 @@ sub getbookmarks() {
 			$creation =~ s/^.*\tcreation\t*(\d*).*/$1/;
 			my $bookmark = $line;
 			$bookmark =~ s/^.*\#(.*)\tcreation.*$/$1/;
-			$bookmarks{$lastguid}{'creation'}=$creation;
+			$bookmarks{$lastguid}{'creation'}=$creation . "000";
 		}
 	}
 


### PR DESCRIPTION
syncoid fails in the following case:
- performing a stream sync (default)
- there are no matching snapshots between source and target
- there is a bookmark on the source matching a snapshot on the target
- there is an unrelated snapshot on the source older than this bookmark

This happens because the units for snapshots and bookmarks were different. syncoid tells `zfs send` to generate an incremental stream starting from the bookmark and going to the unrelated older snapshot. ZFS refuses to do this because it doesn't make sense.

This fix is a bit of hack. Ideally we should share the counter code between `getsnaps` and `getbookmarks`.