### PR TITLE
add --accept-snap filter to syncoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,11 +208,15 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 + --no-sync-snap
 
-	This argument tells syncoid to restrict itself to existing snapshots, instead of creating a semi-ephemeral syncoid snapshot at execution time. Especially useful in multi-target (A->B, A->C) replication schemes, where you might otherwise accumulate a large number of foreign syncoid snapshots.
+	This argument tells syncoid to restrict itself to existing snapshots, instead of creating a semi-ephemeral syncoid snapshot at execution time. Especially useful in multi-target (A->B, A->C) replication schemes, where you might otherwise accumulate a large number of foreign syncoid snapshots. Also useful to avoid having to give the receiving user (if not root, see --no-privilege-elevation) the destroy permission.
 
 + --create-bookmark
 
 	This argument tells syncoid to create a zfs bookmark for the newest snapshot after it got replicated successfully. The bookmark name will be equal to the snapshot name. Only works in combination with the --no-sync-snap option. This can be very useful for irregular replication where the last matching snapshot on the source was already deleted but the bookmark remains so a replication is still possible. 
+
++ --accept-snap=REGEX
+
+	Only consider snaps whose name matches the given regular expression as snap to sync as the most recent snap (only relevant with --no-sync-snap), or the first snap on initial sync. Note that any non-matching snaps in between will still be synced, unless --no-stream is used.
 
 + --no-clone-rollback
 

--- a/syncoid
+++ b/syncoid
@@ -25,7 +25,7 @@ GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsn
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
                    "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
                    "no-clone-handling", "no-privilege-elevation", "force-delete", "no-clone-rollback", "no-rollback",
-                   "create-bookmark", "pv-options=s" => \$pvoptions,
+                   "create-bookmark", "pv-options=s" => \$pvoptions, "accept-snap=s",
                    "mbuffer-size=s" => \$mbuffer_size) or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
@@ -1187,9 +1187,13 @@ sub readablebytes {
 
 sub getoldestsnapshot {
 	my $snaps = shift;
+
+	my $filter = 0; if (defined $args{'accept-snap'}) { $filter = $args{'accept-snap'}; }
 	foreach my $snap ( sort { $snaps{'source'}{$a}{'creation'}<=>$snaps{'source'}{$b}{'creation'} } keys %{ $snaps{'source'} }) {
-		# return on first snap found - it's the oldest
-		return $snap;
+		if (!$filter || $snap =~ /$filter/) {
+			# return on first matching snap found - it's the oldest
+			return $snap;
+		} elsif ($debug) { print "DEBUG: ignoring snap $snap because it does not match $filter\n"; }
 	}
 	# must not have had any snapshots on source - luckily, we already made one, amirite?
 	if (defined ($args{'no-sync-snap'}) ) {
@@ -1201,10 +1205,14 @@ sub getoldestsnapshot {
 
 sub getnewestsnapshot {
 	my $snaps = shift;
+
+	my $filter = 0; if (defined $args{'accept-snap'}) { $filter = $args{'accept-snap'}; }
 	foreach my $snap ( sort { $snaps{'source'}{$b}{'creation'}<=>$snaps{'source'}{$a}{'creation'} } keys %{ $snaps{'source'} }) {
-		# return on first snap found - it's the newest
-		if (!$quiet) { print "NEWEST SNAPSHOT: $snap\n"; }
-		return $snap;
+		if (!$filter || $snap =~ /$filter/) {
+			# return on first matching snap found - it's the newest
+			if (!$quiet) { print "NEWEST SNAPSHOT: $snap\n"; }
+			return $snap;
+		} elsif ($debug) { print "DEBUG: ignoring snap $snap because it does not match $filter\n"; }
 	}
 	# must not have had any snapshots on source - looks like we'd better create one!
 	if (defined ($args{'no-sync-snap'}) ) {
@@ -1897,11 +1905,12 @@ Options:
   --skip-parent         Skips syncing of the parent dataset. Does nothing without '--recursive' option.
   --source-bwlimit=<limit k|m|g|t>  Bandwidth limit in bytes/kbytes/etc per second on the source transfer
   --target-bwlimit=<limit k|m|g|t>  Bandwidth limit in bytes/kbytes/etc per second on the target transfer
-  --mbuffer-size=VALUE  Specify the mbuffer size (default: 16M), please refer to mbuffer(1) manual page.
+  --mbuffer-size=VALUE  Specify the mbuffer size (default: 16M), please refer to mbuffer(1) manual page
   --pv-options=OPTIONS  Configure how pv displays the progress bar, default '-p -t -e -r -b'
   --no-stream           Replicates using newest snapshot instead of intermediates
   --no-sync-snap        Does not create new snapshot, only transfers existing
   --create-bookmark     Creates a zfs bookmark for the newest snapshot on the source after replication succeeds (only works with --no-sync-snap)
+  --accept-snap=REGEX   Only consider snaps whose name matches the given regular expression as snap to sync as the most recent snap (only relevant with --no-sync-snap), or the first snap on initial sync
   --no-clone-rollback   Does not rollback clones on target
   --no-rollback         Does not rollback clones or snapshots on target (it probably requires a readonly target)
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times


### PR DESCRIPTION
This adds a flag `--accept-snap=REGEX` to syncoid, allowing to filter the source snaps that are candidates to become the from or to sync snaps.

Syncoids default behavior to avoid the situation that the snap used on the last sync between to hosts is missing on wither end on the next sync is to create dedicated sync snaps, and prune these itself.

While I assume that that works well in most situations, it does require Syncoid to have the ZFS `destroy` permission on the target. For push replication from a production server, I'd like to have that server have as little access on the backup server as possible, especially I'd like it not to be able to mess with the existing backups.

With `--no-sync-snap`, that seems to be working quite nicely if the target user has the permissions `create,receive,mount,canmount,userprop` on the target filesystem. Except that Syncoid will likely use one of Sanoid's `_frquent` snaps and things break soon thereafter.

The new `--accept-snap` option allows to restrict the possible selection of sync snaps to those that are expected to still exist on the next sync. Obvious downside is that all changes since that pore persistent snap would not be synced.

In my case, I run this as:
```bash
syncoid \
    --recursive --no-sync-snap --create-bookmark \
    --accept-snap=^autosnap_[0-9:_-]+_(?:daily|weekly|monthly|yearly)$ \
    --no-rollback --no-privilege-elevation --sshkey /root/.ssh/syncoid_ed25519 \
    --sendoptions='w' --recvoptions='u o canmount=off' \
    ${dataset} zfs-from-${source}@${target}:backup/${source}/${dataset}
```
And it behaves as intended. I also ran the `test/syncoid` tests, and they passed.

This was suggested a few years ago in #42, but never commented on.

---

Notes:
* This repo was really easy to clone and install, thanks for that! Only thing is that it could mention to use `--reinstall` with `apt install ../sanoid_*_all.deb` when working on `master`.
* I never wrote anything in Perl before (except for PCREs), so please check that the code actually does what one would intuitively think it does.
* At least `sanoid/tests/syncoid/6_reset_resume_state2` seems to be unstable. It failed on my first execution, then passed without changes. I suspect that two snapshots were to be named the same (i.e. same timestamp).