### PR TITLE
include PID in SSH Control path

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1433,7 +1433,7 @@ sub getssh {
 		 $remoteuser =~ s/\@.*$//;
 		if ($remoteuser eq 'root' || $args{'no-privilege-elevation'}) { $isroot = 1; } else { $isroot = 0; }
 		# now we need to establish a persistent master SSH connection
-		$socket = "/tmp/syncoid-$remoteuser-$rhost-" . time();
+		$socket = "/tmp/syncoid-$remoteuser-$rhost-$$-" . time();
 		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
 		close FH;
 


### PR DESCRIPTION
The getssh() function generated a control path using the target host, ssh username, and time() function, which only has 1 second resolution.

This can lead to problems with multiple separate sync jobs running concurrently within 1 second of each other, e.g. when backing up multiple filesystems via systemd services. Both jobs get the same ControlPath and end up using the same multiplexed ssh socket, that is then closed by whichever job finishes first, causing unpredictable errors in the other job when it's stdout or stdin pipe is cut.

The change inserts the PID of the Perl process into the ControlPath to prevent separate processes interfering with each other when running in parallel with less than 1 second between them.