### PR TITLE
Added support for exclude-snaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 	The given regular expression will be matched against all datasets which would be synced by this run and excludes them. This argument can be specified multiple times.
 
++ --exclude=REGEX
+
+	The given regular expression will be matched against all datasets which would be synced by this run and excludes them. This argument can be specified multiple times.
+
++ --exclude=snaps=REGEX
+
+	The given regular expression will be matched against all snapshots which would be synced by this run and excludes them. This argument can be specified multiple times.
+
 + --no-resume
 
 	This argument tells syncoid to not use resumeable zfs send/receive streams.

--- a/syncoid
+++ b/syncoid
@@ -23,7 +23,7 @@ my $pvoptions = "-p -t -e -r -b";
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r", "sendoptions=s", "recvoptions=s",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
+                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "exclude-snap=s@", "skip-parent", "identifier=s",
                    "no-clone-handling", "no-privilege-elevation", "force-delete", "no-clone-rollback", "no-rollback",
                    "create-bookmark", "pv-options=s" => \$pvoptions,
                    "mbuffer-size=s" => \$mbuffer_size) or pod2usage(2);
@@ -1458,6 +1458,23 @@ sub dumphash() {
 	print Dumper($hash);
 }
 
+
+sub shouldexcludesnap{
+	my $snap = $_[0];
+
+	if (!defined $args{'exclude-snap'}) {
+		return 0;
+	}
+        my $excludes_snap = $args{'exclude-snap'};
+        foreach (@$excludes_snap) {
+        	if ($snap =~ /$_/) {
+              		if($debug){ print "DEBUG: exlcuded snapshot $snap because of $_\n"; }
+                        return 1;
+                 }
+       	}
+	return 0;
+}
+
 sub getsnaps() {
 	my ($type,$rhost,$fs,$isroot,%snaps) = @_;
 	my $mysudocmd;
@@ -1497,7 +1514,9 @@ sub getsnaps() {
 			$guid =~ s/^.*\tguid\t*(\d*).*/$1/;
 			my $snap = $line;
 			$snap =~ s/^.*\@(.*)\tguid.*$/$1/;
-			$snaps{$type}{$snap}{'guid'}=$guid;
+			if(shouldexcludesnap($snap) == 0){
+				$snaps{$type}{$snap}{'guid'}=$guid;
+			};
 		}
 	}
 
@@ -1525,11 +1544,12 @@ sub getsnaps() {
 				}
 				$counter += 1;
 			}
-
-			$snaps{$type}{$snap}{'creation'}=$creationsuffix;
+			
+			if(shouldexcludesnap($snap) == 0){
+				$snaps{$type}{$snap}{'creation'}=$creationsuffix;
+			}
 		}
 	}
-
 	return %snaps;
 }
 

--- a/syncoid
+++ b/syncoid
@@ -23,7 +23,7 @@ my $pvoptions = "-p -t -e -r -b";
 my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r", "sendoptions=s", "recvoptions=s",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
-                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "exclude-snap=s@", "skip-parent", "identifier=s",
+                   "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "exclude-snaps=s@", "skip-parent", "identifier=s",
                    "no-clone-handling", "no-privilege-elevation", "force-delete", "no-clone-rollback", "no-rollback",
                    "create-bookmark", "pv-options=s" => \$pvoptions,
                    "mbuffer-size=s" => \$mbuffer_size) or pod2usage(2);
@@ -1462,13 +1462,13 @@ sub dumphash() {
 sub shouldexcludesnap{
 	my $snap = $_[0];
 
-	if (!defined $args{'exclude-snap'}) {
+	if (!defined $args{'exclude-snaps'}) {
 		return 0;
 	}
-        my $excludes_snap = $args{'exclude-snap'};
-        foreach (@$excludes_snap) {
+        my $excludes_snaps = $args{'exclude-snaps'};
+        foreach (@$excludes_snaps) {
         	if ($snap =~ /$_/) {
-              		if($debug){ print "DEBUG: exlcuded snapshot $snap because of $_\n"; }
+              		if($debug){ print "DEBUG: excluded snapshot $snap because of $_\n"; }
                         return 1;
                  }
        	}
@@ -1925,7 +1925,7 @@ Options:
   --no-clone-rollback   Does not rollback clones on target
   --no-rollback         Does not rollback clones or snapshots on target (it probably requires a readonly target)
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times
-  --exclude-snap=REGEX  Exclude specific snapshots which match the given regular expression. Can be specified multiple times
+  --exclude-snaps=REGEX Exclude specific snapshots which match the given regular expression. Can be specified multiple times
   --sendoptions=OPTIONS Use advanced options for zfs send (the arguments are filtered as needed), e.g. syncoid --sendoptions="Lc e" sets zfs send -L -c -e ...
   --recvoptions=OPTIONS Use advanced options for zfs receive (the arguments are filtered as needed), e.g. syncoid --recvoptions="ux recordsize o compression=lz4" sets zfs receive -u -x recordsize -o compression=lz4 ...
   --sshkey=FILE         Specifies a ssh key to use to connect

--- a/syncoid
+++ b/syncoid
@@ -1925,6 +1925,7 @@ Options:
   --no-clone-rollback   Does not rollback clones on target
   --no-rollback         Does not rollback clones or snapshots on target (it probably requires a readonly target)
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times
+  --exclude-snap=REGEX  Exclude specific snapshots which match the given regular expression. Can be specified multiple times
   --sendoptions=OPTIONS Use advanced options for zfs send (the arguments are filtered as needed), e.g. syncoid --sendoptions="Lc e" sets zfs send -L -c -e ...
   --recvoptions=OPTIONS Use advanced options for zfs receive (the arguments are filtered as needed), e.g. syncoid --recvoptions="ux recordsize o compression=lz4" sets zfs receive -u -x recordsize -o compression=lz4 ...
   --sshkey=FILE         Specifies a ssh key to use to connect


### PR DESCRIPTION
Regarding https://github.com/jimsalterjrs/sanoid/issues/153

I've made some changes to add a new command, --exclude-snaps, so that I can avoid replicating certain types of snapshots. For example:

syncoid --exclude-snaps="hourly"

This skips snapshots in getsnaps() matching that term.