### PR TITLE
Fix bogus dates in %changelog to satisfy rpmlint

### DIFF
--- a/packages/rhel/sanoid.spec
+++ b/packages/rhel/sanoid.spec
@@ -111,13 +111,13 @@ echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}
 %endif
 
 %changelog
-* Wed Nov 24 2020 Christoph Klaffl <christoph@phreaker.eu> - 2.1.0
+* Tue Nov 24 2020 Christoph Klaffl <christoph@phreaker.eu> - 2.1.0
 - Bump to 2.1.0
 * Wed Oct 02 2019 Christoph Klaffl <christoph@phreaker.eu> - 2.0.3
 - Bump to 2.0.3
 * Wed Sep 25 2019 Christoph Klaffl <christoph@phreaker.eu> - 2.0.2
 - Bump to 2.0.2
-* Wed Dec 04 2018 Christoph Klaffl <christoph@phreaker.eu> - 2.0.0
+* Tue Dec 04 2018 Christoph Klaffl <christoph@phreaker.eu> - 2.0.0
 - Bump to 2.0.0
 * Sat Apr 28 2018 Dominic Robinson <github@dcrdev.com> - 1.4.18-1
 - Bump to 1.4.18


### PR DESCRIPTION
- 11/24/2020 -> Tuesday
- 12/04/2018 -> Tuesday

Prior to changes:

```
$ rpmlint sanoid.spec
sanoid.spec: E: specfile-error warning: bogus date in %changelog: Wed Nov 24 2020 Christoph Klaffl <christoph@phreaker.eu> - 2.1.0
sanoid.spec: E: specfile-error warning: bogus date in %changelog: Wed Dec 04 2018 Christoph Klaffl <christoph@phreaker.eu> - 2.0.0
0 packages and 1 specfiles checked; 2 errors, 0 warnings.
```

After changes:

```
$ rpmlint sanoid.spec
0 packages and 1 specfiles checked; 0 errors, 0 warnings.
```