### PR TITLE
fix: Warn when newest snapshot is in the future

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -160,17 +160,17 @@ sub monitor_snapshots {
 			my $typecrit = $type . '_crit';
 			my $warn = convertTimePeriod($config{$section}{$typewarn}, $smallerperiod);
 			my $crit = convertTimePeriod($config{$section}{$typecrit}, $smallerperiod);
-			my $elapsed = -1;
+			my $elapsed;
 			if (defined $snapsbytype{$path}{$type}{'newest'}) {
 				$elapsed = $snapsbytype{$path}{$type}{'newest'};
 			}
 			my $dispelapsed = displaytime($elapsed);
 			my $dispwarn = displaytime($warn);
 			my $dispcrit = displaytime($crit);
-			if ( $elapsed > $crit || $elapsed == -1) {
+			if ($elapsed > $crit || !defined($elapsed)) {
 				if ($crit > 0) {
 					if (! $config{$section}{'monitor_dont_crit'}) { $errorlevel = 2; }
-					if ($elapsed == -1) {
+					if (!defined($elapsed)) {
 						push @msgs, "CRIT: $path has no $type snapshots at all!";
 					} else {
 						push @msgs, "CRIT: $path newest $type snapshot is $dispelapsed old (should be < $dispcrit)";
@@ -181,6 +181,10 @@ sub monitor_snapshots {
 					if (! $config{$section}{'monitor_dont_warn'} && ($errorlevel < 2) ) { $errorlevel = 1; }
 					push @msgs, "WARN: $path newest $type snapshot is $dispelapsed old (should be < $dispwarn)";
 				}
+			} elsif ($elapsed < 0) {
+				# The most recent snapshot is in the future!
+				if (! $config{$section}{'monitor_dont_warn'} && ($errorlevel < 2) ) { $errorlevel = 1; }
+				push @msgs, "WARN: $path newest $type snapshot is $dispelapsed old (in the future)";
 			} else {
 				# push @msgs .= "OK: $path newest $type snapshot is $dispelapsed old \n";
 			}


### PR DESCRIPTION
### Description

Option **--monitor-snapshots** issues a _Warning_ or a _Critical_ when newest snapshot is too old based on the thresholds defined in the Sanoid configuration.

However, it reports an _OK_ status when newest snapshot is in the future. This can happen when system time is wrong (in the future) for some time and then returns to normal. In such a situation, this may prevent the creation of new snapshots for a while and so we need to be alerted.

### How to test

On a Linux Debian 10 server:
```
# Stop timesyncd
systemctl stop systemd-timesyncd.service

# Change date (+1 month)
date --set="$(date --date='next month')"

# take snapshots (they will be dated one month in the future)
./sanoid --take-snapshots

# Start timesyncd (the date will come back on time)
systemctl start systemd-timesyncd.service

# Monitor snapshots
## actual behaviour
./sanoid --monitor-snapshots ; echo $?
OK: all monitored datasets (tank/data2) have fresh snapshots
0
## new behaviour (this PR)
./sanoid --monitor-snapshots ; echo $?
WARN: tank/data2 newest daily snapshot is -29d -23h -56m -44s old (in the future), WARN: tank/data2 newest hourly snapshot is -29d -23h -56m -44s old (in the future), WARN: tank/data2 newest monthly snapshot is -4d -10h -29m -19s old (in the future)
1
```

### Open questions

- The decision to issue a Warning is arbitrary. It could also be a Critical.
- We could emit a Warning when newest snapshot is in the near future, and a Critical when it's in the distant future, based on the same thresholds defined to detect recentness of the newest snapshots.
- We could even add configuration options to define whether we want to issue a Warning, a Critical or just ignore such a situation. But that may be excessive for this infrequent event?