### PR TITLE
feat: Samba friendly snapshot name

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -546,7 +546,7 @@ sub take_snapshots {
 			my @snapshots;
 
 			foreach my $type (@types) {
-				my $snapname = "autosnap_$datestamp{'sortable'}_$type";
+				my $snapname = "autosnap_${type}_UTC_$datestamp{'sortable'}";
 				push(@snapshots, $snapname);
 			}
 
@@ -827,11 +827,11 @@ sub getsnaps {
 	}
 
 	foreach my $snap (@rawsnaps) {
-		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*ly)\t*creation\t*(\d*)/);
+		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@([^\t]+)\t*creation\t*(\d*)/);
 
 		# avoid pissing off use warnings
 		if (defined $snapname) {
-			my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
+			my ($snaptype) = ($snapname =~ m/_(\w*ly)_/);
 			if ($snapname =~ /^autosnap/) {
 				$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 				$snaps{$fs}{$snapname}{'type'}=$snaptype;


### PR DESCRIPTION
Renaming a snapshot to make it easier to handle with Samba's vfs_shadow_copy2.

After applying the above changes, the following settings in smb.conf should work.

```
     shadow:format       = _UTC_%Y-%m-%d_%H:%M:%S                                                                                                                                                          
     shadow:snapprefix   = ^autosnap_\(yearly\)\{0,1\}\(monthly\)\{0,1\}\(weekly\)\{0,1\}\(daily\)\{0,1\}\(hourly\)\{0,1\}\(frequently\)\{0,1\}                                                            
     shadow:delimiter    = _UTC_                                                                                                                                                                           
     shadow:localtime    = no
```