### PR TITLE
append a rand int to the socket name.

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1488,7 +1488,7 @@ sub getssh {
 	if ($rhost ne "") {
 		if ($remoteuser eq 'root' || $args{'no-privilege-elevation'}) { $isroot = 1; } else { $isroot = 0; }
 		# now we need to establish a persistent master SSH connection
-		$socket = "/tmp/syncoid-$rhost-" . time();
+		$socket = "/tmp/syncoid-$rhost-" . time() . "-" . int(rand(10000));
 
 		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
 		close FH;


### PR DESCRIPTION
Running more than one 'syncoid' at the same time to the same host resulted in two jobs referencing the same socket.
Often results in "already exists, disabling multiplexing" but has in more than one occasion failed with the following:

ControlSocket /tmp/syncoid-zfsbackup-zfsbackup@10.0.0.1-1649107066 already exists, disabling multiplexing
lzop: Inappropriate ioctl for device: <stdin>
CRITICAL ERROR: ssh     -S /tmp/syncoid-zfsbackup-zfsbackup@10.0.0.1-1649107066 zfsbackup@10.0.0.1 ' zfs send  -I '"'"'pool/office'"'"'@'"'"'autosnap_2022-04-04_21:00:00_frequently'"'"' '"'"'pool/office'"'"'@'"'"'autosnap_2022-04-04_21:15:00_frequently'"'"' | lzop  | mbuffer -R 5m -q -s 128k -m 16M 2>/dev/null' | mbuffer  -q -s 128k -m 16M 2>/dev/null | lzop -dfc | pv -s 18356312 |  zfs receive  -s -F 'zfs-pool/vault/office' 2>&1 failed: 256 at /usr/sbin/syncoid line 786.

Sample use-case: 
Using Monit, Cron, or some other scheduler to trigger more than syncoid to the same host to sync two datasets.
Stagger the sync so that no two jobs get started at the same time, or add some form of randomization to the socket name so that two jobs may start at the same time.