### PR TITLE
Provide reason in warning message

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -901,7 +901,7 @@ sub init {
 
 			foreach my $key (keys %{$ini{'template_default'}}) {
 				if ($key =~ /template|recursive/) {
-					warn "ignored key '$key' from user-defined default template.\n";
+					warn "ignored key '$key' from user-defined default template because it can not be used in the default template.\n";
 					next;
 				}
 				if ($args{'debug'}) { print "DEBUG: overriding $key on $section with value from user-defined default template.\n"; }
@@ -920,7 +920,7 @@ sub init {
 				my $template = 'template_'.$rawtemplate;
 				foreach my $key (keys %{$ini{$template}}) {
 					if ($key =~ /template|recursive/) {
-						warn "ignored key '$key' from '$rawtemplate' template.\n";
+						warn "ignored key '$key' from '$rawtemplate' template because it can not be used in a template.\nPlease use it explicitly in all configs that use '$rawtemplate'.\n";
 						next;
 					}
 					if ($args{'debug'}) { print "DEBUG: overriding $key on $section with value from user-defined template $template.\n"; }


### PR DESCRIPTION
I got this warning when I wanted to create a template with "recursive = yes" and had to look at the sourcecode to find it's not allowed in templates.
This PR proposes to clarify the reason in the warning message to make it less confusing. Please revise the language as I'm not a native speaker.