### PR TITLE
Add sudo to last Debian install step

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ cd sanoid
 git checkout $(git tag | grep "^v" | tail -n 1)
 ln -s packages/debian .
 dpkg-buildpackage -uc -us
-apt install ../sanoid_*_all.deb
+sudo apt install ../sanoid_*_all.deb
 ```
 
 Enable sanoid timer:


### PR DESCRIPTION
The last install step for Debian involves installing the generated package via apt. However, this requires sudo (at least by default.) Add sudo to the last step to make each step work properly.