### PR TITLE
Add preserve-compression option

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -25,8 +25,8 @@ GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsn
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
                    "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
                    "no-clone-handling", "no-privilege-elevation", "force-delete", "create-bookmark", 
-                   "pv-options=s" => \$pvoptions, "keep-sync-snap", "preserve-recordsize", "mbuffer-size=s" => \$mbuffer_size) 
-                   or pod2usage(2);
+                   "pv-options=s" => \$pvoptions, "keep-sync-snap", "preserve-recordsize", "preserve-compression",
+		   "mbuffer-size=s" => \$mbuffer_size) or pod2usage(2);
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -443,6 +443,11 @@ sub syncdataset {
 				$recvoptions .= "-o recordsize=$recordsize"
 			}
 		}
+		
+		if (defined $args{'preserve-compression'}) {
+			my $compression = getzfsvalue($sourcehost,$sourcefs,$sourceisroot,'compression');
+			$recvoptions .= " -o compression=$compression"
+		}		
 
 		my $sendcmd = "$sourcesudocmd $zfscmd send $sendoptions $sourcefsescaped\@$oldestsnapescaped";
 		my $recvcmd = "$targetsudocmd $zfscmd receive $recvoptions $receiveextraargs $forcedrecv $targetfsescaped";


### PR DESCRIPTION
Datasets can have different compression options depending on the type of data stored, similar to the reason for having unique record sizes. This allow the preservation of the compression type set on a data set when replicating recursively.