### PR TITLE
Add --preserve-compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 + --preserve-recordsize
 
 	This argument tells syncoid to set the recordsize on the target before writing any data to it matching the one set on the replication src. This only applies to initial sends.
+	
++ --preserve-compression
+
+	This argument tells syncoid to set the compression type on the target before writing any data to it matching the one set on the replication src. This only applies to initial sends.
 
 + --no-clone-rollback
 


### PR DESCRIPTION
This option allows the compression type to be preserved from the source host to the destination. Useful where there are different compression types used in various datasets that are being replicated as part of a recursive tree.