### PR TITLE
Include syncoid remote user requirment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -206,3 +206,12 @@ Adapt the timer interval to the lowest configured snapshot interval.
 Take a look at the files `sanoid.defaults.conf` and `sanoid.conf` for all possible configuration options.
 
 Also have a look at the README.md for a simpler suggestion for `sanoid.conf`.
+
+## Syncoid
+If you are pushing or pulling from a remote host, create a user with privileges to `ssh` as well as `sudo`. To ensure that `zfs send/receive` can execute, adjust the privileges of the user to execute `sudo` **without** a password for only the `zfs` binary (run `which zfs` to find the path of the `zfs` binary). Modify `/etc/sudoers` by running `# visudo`. Add the following line for your user.
+
+```
+...
+<user> ALL=NOPASSWD: <path of zfs binary>
+...
+```


### PR DESCRIPTION
Add requirement for syncoid w/ remote hosts to be able to sudo without a password.
Recommends a least privilege configuration option for enabling `NOPASSWD`

I created this PR to fix a previous PR that seems to have lost support from the original author: https://github.com/jimsalterjrs/sanoid/pull/670