### PR TITLE
bring back no-rollback option

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -24,7 +24,7 @@ my %args = ('sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r", "sendoptions=s", "recvoptions=s",
                    "source-bwlimit=s", "target-bwlimit=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
                    "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
-                   "no-clone-handling", "no-privilege-elevation", "force-delete", "create-bookmark", 
+                   "no-clone-handling", "no-privilege-elevation", "force-delete", "no-rollback", "create-bookmark",
                    "pv-options=s" => \$pvoptions, "keep-sync-snap", "preserve-recordsize", "mbuffer-size=s" => \$mbuffer_size) 
                    or pod2usage(2);
 
@@ -288,8 +288,11 @@ sub syncdataset {
 	my $sourcefsescaped = escapeshellparam($sourcefs);
 	my $targetfsescaped = escapeshellparam($targetfs);
 
-	# keep forcedrecv as a variable to allow us to disable it with an optional argument later if necessary
+	# if no rollbacks are allowed, disable forced receive
 	my $forcedrecv = "-F";
+	if (defined $args{'no-rollback'}) {
+		$forcedrecv = "";
+	}
 
 	if ($debug) { print "DEBUG: syncing source $sourcefs to target $targetfs.\n"; }
 
@@ -1956,6 +1959,7 @@ Options:
   --keep-sync-snap      Don't destroy created sync snapshots
   --create-bookmark     Creates a zfs bookmark for the newest snapshot on the source after replication succeeds (only works with --no-sync-snap)
   --preserve-recordsize Preserves the recordsize on initial sends to the target
+  --no-rollback         Does not rollback snapshots on target (it probably requires a readonly target)
   --exclude=REGEX       Exclude specific datasets which match the given regular expression. Can be specified multiple times
   --sendoptions=OPTIONS Use advanced options for zfs send (the arguments are filtered as needed), e.g. syncoid --sendoptions="Lc e" sets zfs send -L -c -e ...
   --recvoptions=OPTIONS Use advanced options for zfs receive (the arguments are filtered as needed), e.g. syncoid --recvoptions="ux recordsize o compression=lz4" sets zfs receive -u -x recordsize -o compression=lz4 ...


### PR DESCRIPTION
this brings back the --no-rollback option without reverting to the old way of explicit rolling back the target filesystem.
The option is very useful to others (https://www.reddit.com/r/zfs/comments/xcffnn/syncoid_norollback_option_gone/) and me.