### PR TITLE
improve accuracy of zfs receive check

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1113,7 +1113,7 @@ sub iszfsbusy {
 
 	foreach my $process (@processes) {
 		# if ($debug) { print "DEBUG: checking process $process...\n"; }
-		if ($process =~ /zfs *(receive|recv).*\Q$fs\E\Z/) {
+		if ($process =~ /zfs *(receive|recv)[^\/]*\Q$fs\E\Z/) {
 			# there's already a zfs receive process for our target filesystem - return true
 			if ($debug) { print "DEBUG: process $process matches target $fs!\n"; }
 			return 1;


### PR DESCRIPTION
previously the following scenario

host1: pool1 --- syncoid over ssh ---> host2: pool1
host2: pool1 --- syncoid local --------> host2: backup/pool1

would fail if run concurrently, because the zfs receive check wouldn't differentiate between "pool1" and "backup/pool1"