### PR TITLE
syncoid should exit with an error if the specified src dataset doesn'…

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -141,6 +141,8 @@ my %avail = checkcommands();
 my %snaps;
 my $exitcode = 0;
 
+my $replicationCount = 0;
+
 ## break here to call replication individually so that we ##
 ## can loop across children separately, for recursive     ##
 ## replication                                            ##
@@ -297,7 +299,7 @@ sub syncdataset {
 
 	if (!defined $sync) {
 		# zfs already printed the corresponding error
-		if ($error =~ /\bdataset does not exist\b/) {
+		if ($error =~ /\bdataset does not exist\b/ && $replicationCount > 0) {
 			if (!$quiet) { print "WARN Skipping dataset (dataset no longer exists): $sourcefs...\n"; }
 			return 0;
 		}
@@ -810,6 +812,8 @@ sub syncdataset {
 			#setzfsvalue($targethost,$targetfs,$targetisroot,'readonly',$originaltargetreadonly);
 		}
 	}
+
+	$replicationCount++;
 
 	if (defined $args{'no-sync-snap'}) {
 		if (defined $args{'create-bookmark'}) {


### PR DESCRIPTION
…t exist (and only skip child datasets which vanished)

Fixes #754 