### PR TITLE
Clarified that compression is on the wire

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ As of 1.4.18, syncoid also automatically supports and enables resume of interrup
 
 + --compress <compression type>
 
-	Currently accepted options: gzip, pigz-fast, pigz-slow, zstd-fast, zstd-slow, lz4, xz, lzo (default) & none. If the selected compression method is unavailable on the source and destination, no compression will be used.
+	Compression method to use for network transfer. Currently accepted options: gzip, pigz-fast, pigz-slow, zstd-fast, zstd-slow, lz4, xz, lzo (default) & none. If the selected compression method is unavailable on the source and destination, no compression will be used.
 
 + --source-bwlimit <limit t|g|m|k>
 


### PR DESCRIPTION
Since it is possible people might use different compression options on the destination dataset, it seems helpful to clarify this option is for the wire transfer, not overriding destination compression.