### PR TITLE
trim config values

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -905,6 +905,8 @@ sub init {
 				warn "duplicate key '$key' in section '$section', using the value from the first occurence and ignoring the others.\n";
 				$ini{$section}{$key} = $value->[0];
 			}
+			# trim
+			$ini{$section}{$key} =~ s/^\s+|\s+$//g;
 		}
 
 		if ($section =~ /^template_/) { next; } # don't process templates directly


### PR DESCRIPTION
leading and/or trailing spaces in the config values will lead to weird issues which are hard to track down, so trim them to get rid of those cases.

Fixes #834 