### PR TITLE
debian: add openzfs-zfsutils as an alternative to zfsutils-linux

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -12,7 +12,7 @@ Package: sanoid
 Architecture: all
 Depends: libcapture-tiny-perl,
          libconfig-inifiles-perl,
-         zfsutils-linux | zfs,
+         zfsutils-linux | zfs | openzfs-zfsutils,
          ${misc:Depends},
          ${perl:Depends}
 Recommends: gzip,


### PR DESCRIPTION
The package produced by ZFS 2.2.0 `make native-deb-utils` is called `openzfs-zfsutils`.