### PR TITLE
fix zfs-get for "--preserve-properties" and tests

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1357,9 +1357,9 @@ sub getlocalzfsvalues {
 	if ($debug) { print "DEBUG: getting locally set values of properties on $fs...\n"; }
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	if ($debug) { print "$rhost $mysudocmd $zfscmd get all -s local -H $fsescaped\n"; }
+	if ($debug) { print "$rhost $mysudocmd $zfscmd get -s local -H all $fsescaped\n"; }
 	my ($values, $error, $exit) = capture {
-		system("$rhost $mysudocmd $zfscmd get all -s local -H $fsescaped");
+		system("$rhost $mysudocmd $zfscmd get -s local -H all $fsescaped");
 	};
 
 	my %properties=();

--- a/tests/syncoid/7_preserve_recordsize/run.sh
+++ b/tests/syncoid/7_preserve_recordsize/run.sh
@@ -32,17 +32,17 @@ zfs create -o recordsize=32k "${POOL_NAME}"/src/32
 zfs create -o recordsize=128k "${POOL_NAME}"/src/128
 ../../../syncoid --preserve-recordsize --recursive --debug --compress=none "${POOL_NAME}"/src "${POOL_NAME}"/dst
 
-zfs get recordsize -t filesystem -r "${POOL_NAME}"/dst
-zfs get volblocksize -t volume -r "${POOL_NAME}"/dst
+zfs get -t filesystem -r recordsize "${POOL_NAME}"/dst
+zfs get -t volume -r volblocksize "${POOL_NAME}"/dst
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst/16)" != "16K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst/16)" != "16K" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst/32)" != "32K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst/32)" != "32K" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst/128)" != "128K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst/128)" != "128K" ]; then
 	exit 1
 fi

--- a/tests/syncoid/9_preserve_properties/run.sh
+++ b/tests/syncoid/9_preserve_properties/run.sh
@@ -33,34 +33,34 @@ zfs create -o recordsize=32k -o acltype=posixacl "${POOL_NAME}"/src/32
 ../../../syncoid --preserve-properties --recursive --debug --compress=none "${POOL_NAME}"/src "${POOL_NAME}"/dst
 
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst)" != "16K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst)" != "16K" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get mountpoint -H -o value -t filesystem "${POOL_NAME}"/dst)" != "none" ]; then
+if [ "$(zfs get -H -o value -t filesystem mountpoint "${POOL_NAME}"/dst)" != "none" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get xattr -H -o value -t filesystem "${POOL_NAME}"/dst)" != "on" ]; then
+if [ "$(zfs get -H -o value -t filesystem xattr "${POOL_NAME}"/dst)" != "on" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get primarycache -H -o value -t filesystem "${POOL_NAME}"/dst)" != "none" ]; then
+if [ "$(zfs get -H -o value -t filesystem primarycache "${POOL_NAME}"/dst)" != "none" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst/16)" != "16K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst/16)" != "16K" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get primarycache -H -o value -t filesystem "${POOL_NAME}"/dst/16)" != "none" ]; then
+if [ "$(zfs get -H -o value -t filesystem primarycache "${POOL_NAME}"/dst/16)" != "none" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get recordsize -H -o value -t filesystem "${POOL_NAME}"/dst/32)" != "32K" ]; then
+if [ "$(zfs get -H -o value -t filesystem recordsize "${POOL_NAME}"/dst/32)" != "32K" ]; then
 	exit 1
 fi
 
-if [ "$(zfs get acltype -H -o value -t filesystem "${POOL_NAME}"/dst/32)" != "posix" ]; then
+if [ "$(zfs get -H -o value -t filesystem acltype "${POOL_NAME}"/dst/32)" != "posix" ]; then
 	exit 1
 fi


### PR DESCRIPTION
Some syncoid tests and the "--preserve-properties" flag are failing on ZoL/ZoF devices with the following test errors:
```shell
DEBUG: getting locally set values of properties on syncoid-test-9/src/zvol16...
  zfs get all -s local -H 'syncoid-test-9/src/zvol16'
WARNING: getlocalzfsvalues failed for syncoid-test-9/src/zvol16: cannot open '-s
': dataset does not exist
cannot open 'local': dataset does not exist
cannot open '-H': dataset does not exist
``` 
```shell
+ zfs get recordsize -t filesystem -r syncoid-test-7/dst
cannot open '-t': dataset does not exist
cannot open 'filesystem': dataset does not exist
cannot open '-r': dataset does not exist
``` 
Fixed by moving the property field directly before the dataset for zfs-gets in the affected files. This mimics how zfs-get is used throughout the rest of the project.