### PR TITLE
fix(syncoid): regather $snaps on --delete-target-snapshots flag

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -867,13 +867,13 @@ sub syncdataset {
 		# snapshots first.
 
 		# regather snapshots on source and target
-		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
+		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot,0);
 
-                if ($targetexists) {
-                    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
-                    my %sourcesnaps = %snaps;
-                    %snaps = (%sourcesnaps, %targetsnaps);
-                }
+		if ($targetexists) {
+		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot,0);
+		    my %sourcesnaps = %snaps;
+		    %snaps = (%sourcesnaps, %targetsnaps);
+		}
 
 		my @to_delete = sort { sortsnapshots(\%snaps, $a, $b) } grep {!exists $snaps{'source'}{$_}} keys %{ $snaps{'target'} };
 		while (@to_delete) {

--- a/syncoid
+++ b/syncoid
@@ -865,6 +865,16 @@ sub syncdataset {
 		# those that exist on the source. Remaining are the snapshots
 		# that are only on the target. Then sort to remove the oldest
 		# snapshots first.
+
+		# regather snapshots on source and target
+		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
+
+                if ($targetexists) {
+                    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
+                    my %sourcesnaps = %snaps;
+                    %snaps = (%sourcesnaps, %targetsnaps);
+                }
+
 		my @to_delete = sort { sortsnapshots(\%snaps, $a, $b) } grep {!exists $snaps{'source'}{$_}} keys %{ $snaps{'target'} };
 		while (@to_delete) {
 			# Create batch of snapshots to remove


### PR DESCRIPTION
## Issue

I've noticed that during Syncoid runs when using the `--delete-target-snapshots` and `--no-sync-snap` flags, there are issues with zfs rolling back snapshots during a sync. 

The sync workflow looks something like this:

- Initial start
  - Source: snap1, snap2
  - Target: 
- Sync snapshots to Target, take new snapshot on Source, delete snapshot on Source that isn't newest
  - Source: snap1, snap3
  - Target: snap1, snap2
- Error occurs here when trying to run a subsequent sync as the `%snaps` are cached from before the rollback, but during the sync the snapshots are rolled back to the latest common and then `%snaps` contains snapshots to be deleted that no longer exist

## Sync Outputs

```output
### initial sync
root@target ~
 # syncoid root@source:source/ubuntu target/ubuntu --delete-target-snapshots --no-sync-snap
NEWEST SNAPSHOT: snapshot-snap2
Removing target/ubuntu because no matching snapshots were found
NEWEST SNAPSHOT: snapshot-snap2
INFO: Sending oldest full snapshot source/ubuntu@snapshot-snap0 (~ 1.0 GB) to new target filesystem:
1.05GiB 0:00:08 [ 132MiB/s] [=========================================================] 103%
INFO: Updating new target filesystem with incremental target/ubuntu@snapshot-snap0 ... snapshot-snap2 (~ 3.1 MB):
3.15MiB 0:00:00 [11.5MiB/s] [=========================================================] 102%
### problematic sync
root@target ~
 # syncoid root@source:source/ubuntu target/ubuntu --delete-target-snapshots --no-sync-snap
NEWEST SNAPSHOT: snapshot-snap3
Sending incremental source/ubuntu@snapshot-snap1 ... snapshot-snap3 (~ 14.3 MB):
15.1MiB 0:00:00 [ 120MiB/s] [=========================================================] 105%
 zfs destroy 'target/ubuntu'@snapshot-snap2 failed: could not find any snapshots to destroy; check snapshot names.
root@target ~
```

## Proposed Solution

I found the section where `%snaps` is being set and copied it to the `--delete-target-snapshots` section, but I could also make that snippet a subroutine and call it in the original location as well as `--delete-target-snapshots` section. Mainly wanted to leave that to the maintainer(s) to decide