### PR TITLE
[findoid] support relative paths

### DIFF
--- a/findoid
+++ b/findoid
@@ -25,6 +25,9 @@ if ($args{'path'} eq '') {
 	}
 }
 
+# resolve given path to a canonical one
+$args{'path'} = Cwd::realpath($args{'path'});
+
 my $dataset = getdataset($args{'path'});
 
 my %versions = getversions($args{'path'}, $dataset);


### PR DESCRIPTION
currently relative paths won't work properly with findoid. this pr resolves the relative path to a canonical one to make it work.