### PR TITLE
sanoid #912: sanoid --prune-snapshots performance boost by making --f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ For more full details on sanoid.conf settings see [Wiki page](https://github.com
 
 	This will process your sanoid.conf file, it will NOT create snapshots, but it will purge expired ones.
 
++ --no-force-prune
+
+	Double-check that no send/recv is in progress before pruning a snapshot. This restores the behavoir that was default up to version 2.2.0. May slow down by a second for pruned snapshot. Normally, this should not be needed, because zfs does not drop busy snapshots anyway.
+
 + --force-prune
 
 	Purges expired snapshots even if a send/recv is in progress

--- a/sanoid
+++ b/sanoid
@@ -25,7 +25,8 @@ my %args = (
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
                    "configdir=s", "cache-dir=s", "run-dir=s",
                    "monitor-health", "force-update",
-                   "monitor-snapshots", "take-snapshots", "prune-snapshots", "force-prune",
+                   "monitor-snapshots", "take-snapshots", "prune-snapshots",
+                   "no-force-prune",
                    "monitor-capacity"
           ) or pod2usage(2);
 
@@ -40,7 +41,7 @@ my $cacheTTL = 900; # 15 minutes
 
 # Allow a much older snapshot cache file than default if _only_ "--monitor-*" action commands are given
 # (ignore "--verbose", "--configdir" etc)
-if (($args{'monitor-snapshots'} || $args{'monitor-health'} || $args{'monitor-capacity'}) && ! ($args{'cron'} || $args{'force-update'} || $args{'take-snapshots'} || $args{'prune-snapshots'} || $args{'force-prune'})) {
+if (($args{'monitor-snapshots'} || $args{'monitor-health'} || $args{'monitor-capacity'}) && ! ($args{'cron'} || $args{'force-update'} || $args{'take-snapshots'} || $args{'prune-snapshots'} || $args{'no-force-prune'})) {
 	# The command combination above must not assert true for any command that takes or prunes snapshots
 	$cacheTTL = 18000; # 5 hours
 	if ($args{'debug'}) { print "DEBUG: command combo means that the cache file (provided it exists) will be allowed to be older than default.\n"; }
@@ -349,7 +350,7 @@ sub prune_snapshots {
 							}
 
 							if ($args{'verbose'}) { print "INFO: pruning $snap ... \n"; }
-							if (!$args{'force-prune'} && iszfsbusy($path)) {
+							if ($args{'no-force-prune'} && iszfsbusy($path)) {
 								if ($args{'verbose'}) { print "INFO: deferring pruning of $snap - $path is currently in zfs send or receive.\n"; }
 							} else {
 								if (! $args{'readonly'}) {
@@ -1752,7 +1753,7 @@ Options:
   --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
   --take-snapshots      Creates snapshots as specified in sanoid.conf
   --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
-  --force-prune         Purges expired snapshots even if a send/recv is in progress
+  --no-force-prune      Double-check that no send/recv is in progress before pruning
 
   --help                Prints this helptext
   --version             Prints the version number


### PR DESCRIPTION
…orce-prune default (and adding --no-force-prune to get old behavior)

for https://github.com/jimsalterjrs/sanoid/issues/912#

Option 1 dev/sde/no-force-prune - the "least invasive" probably is to make --force-prune default and add --no-force-prune as option to restore the old behavior