### PR TITLE
sanoid #912: sanoid --prune-snapshots performance boost by making --f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ For more full details on sanoid.conf settings see [Wiki page](https://github.com
 
 	This will process your sanoid.conf file, it will NOT create snapshots, but it will purge expired ones.
 
-+ --force-prune
++ --double-check-prune
 
-	Purges expired snapshots even if a send/recv is in progress
+	Double-check that no send/recv is in progress before pruning a snapshot. May slow down by a second for pruned snapshot. Normally, this should not be needed, because zfs does not drop busy snapshots anyway.
 
 + --monitor-snapshots
 

--- a/sanoid
+++ b/sanoid
@@ -25,7 +25,8 @@ my %args = (
 GetOptions(\%args, "verbose", "debug", "cron", "readonly", "quiet",
                    "configdir=s", "cache-dir=s", "run-dir=s",
                    "monitor-health", "force-update",
-                   "monitor-snapshots", "take-snapshots", "prune-snapshots", "force-prune",
+                   "monitor-snapshots", "take-snapshots", "prune-snapshots",
+                   "double-check-prune",
                    "monitor-capacity"
           ) or pod2usage(2);
 
@@ -40,7 +41,7 @@ my $cacheTTL = 900; # 15 minutes
 
 # Allow a much older snapshot cache file than default if _only_ "--monitor-*" action commands are given
 # (ignore "--verbose", "--configdir" etc)
-if (($args{'monitor-snapshots'} || $args{'monitor-health'} || $args{'monitor-capacity'}) && ! ($args{'cron'} || $args{'force-update'} || $args{'take-snapshots'} || $args{'prune-snapshots'} || $args{'force-prune'})) {
+if (($args{'monitor-snapshots'} || $args{'monitor-health'} || $args{'monitor-capacity'}) && ! ($args{'cron'} || $args{'force-update'} || $args{'take-snapshots'} || $args{'prune-snapshots'} || $args{'double-check-prune'})) {
 	# The command combination above must not assert true for any command that takes or prunes snapshots
 	$cacheTTL = 18000; # 5 hours
 	if ($args{'debug'}) { print "DEBUG: command combo means that the cache file (provided it exists) will be allowed to be older than default.\n"; }
@@ -349,7 +350,7 @@ sub prune_snapshots {
 							}
 
 							if ($args{'verbose'}) { print "INFO: pruning $snap ... \n"; }
-							if (!$args{'force-prune'} && iszfsbusy($path)) {
+							if ($args{'double-check-prune'} && iszfsbusy($path)) {
 								if ($args{'verbose'}) { print "INFO: deferring pruning of $snap - $path is currently in zfs send or receive.\n"; }
 							} else {
 								if (! $args{'readonly'}) {
@@ -1752,7 +1753,7 @@ Options:
   --monitor-snapshots   Reports on snapshot "health", in a Nagios compatible format
   --take-snapshots      Creates snapshots as specified in sanoid.conf
   --prune-snapshots     Purges expired snapshots as specified in sanoid.conf
-  --force-prune         Purges expired snapshots even if a send/recv is in progress
+  --double-check-prune  Double-check that no send/recv is in progress before pruning
 
   --help                Prints this helptext
   --version             Prints the version number


### PR DESCRIPTION
…orce-prune default (and adding --double-check-prune to get old behavior)


for https://github.com/jimsalterjrs/sanoid/issues/912#

Option dev/sde/double-check-prune - I think the name --no-force-prune is irritating, so it might be renamed to --double-check-prune