### PR TITLE
syncoid: Fix multiple regressions caused by #818

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1874,6 +1874,8 @@ sub getsnaps {
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
+	my $rhostOriginal = $rhost;
+
 	if ($rhost ne '') {
 		$rhost = "$sshcmd $rhost";
 		# double escaping needed
@@ -1895,7 +1897,7 @@ sub getsnaps {
 	close FH or do {
 		if (!$use_fallback) {
 			writelog('WARN', "snapshot listing failed, trying fallback command");
-			return getsnaps($type, $rhost, $fs, $isroot, 1, %snaps);
+			return getsnaps($type, $rhostOriginal, $fs, $isroot, 1, %snaps);
 		}
 		die "CRITICAL ERROR: snapshots couldn't be listed for $fs (exit code $?)";
 	};

--- a/syncoid
+++ b/syncoid
@@ -1911,7 +1911,7 @@ sub getsnaps {
 		die "CRITICAL ERROR: Unexpected line format in $line" unless defined $value;
 
 		my (undef, $snap) = split /@/, $dataset;
-		die "CRITICAL ERROR: Unexpected dataset format in $line" unless $snap;
+		next unless length $snap;
 
         if (!snapisincluded($snap)) { next; }
 

--- a/syncoid
+++ b/syncoid
@@ -194,6 +194,9 @@ if (length $args{'insecure-direct-connection'}) {
 # warn user of anything missing, then continue with sync.
 my %avail = checkcommands();
 
+# host => { supports_type_filter => 1/0, supported_properties => ['guid', 'creation', ...] }
+my %host_zfs_get_features;
+
 my %snaps;
 my $exitcode = 0;
 
@@ -415,10 +418,10 @@ sub syncdataset {
 	if (!defined($receivetoken)) {
 		# build hashes of the snaps on the source and target filesystems.
 
-		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot,0);
+		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
 
 		if ($targetexists) {
-		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot,0);
+		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
 		    my %sourcesnaps = %snaps;
 		    %snaps = (%sourcesnaps, %targetsnaps);
 		}
@@ -858,10 +861,10 @@ sub syncdataset {
 		# snapshots first.
 
 		# regather snapshots on source and target
-		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot,0);
+		%snaps = getsnaps('source',$sourcehost,$sourcefs,$sourceisroot);
 
 		if ($targetexists) {
-		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot,0);
+		    my %targetsnaps = getsnaps('target',$targethost,$targetfs,$targetisroot);
 		    my %sourcesnaps = %snaps;
 		    %snaps = (%sourcesnaps, %targetsnaps);
 		}
@@ -1393,6 +1396,48 @@ sub checkcommands {
 	return %avail;
 }
 
+sub check_zfs_get_features {
+	my ($rhost, $mysudocmd, $zfscmd) = @_;
+	my $host = $rhost ? (split(/\s+/, $rhost))[-1] : "localhost";
+
+	return $host_zfs_get_features{$host} if exists $host_zfs_get_features{$host};
+
+	writelog('DEBUG', "Checking `zfs get` features on host \"$host\"...");
+
+	$host_zfs_get_features{$host} = {
+		supports_type_filter => 0,
+		supported_properties => []
+	};
+
+	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot '' ''";
+	open my $fh_t, "$check_t_option_cmd 2>&1 |";
+	my $output_t = <$fh_t>;
+	close $fh_t;
+
+	if ($output_t !~ /^\Qinvalid option\E/) {
+		$host_zfs_get_features{$host}->{supports_type_filter} = 1;
+	}
+
+	writelog('DEBUG', "Host \"$host\" has `zfs get -t`?: $host_zfs_get_features{$host}->{supports_type_filter}");
+
+	my @properties_to_check = ('guid', 'creation', 'createtxg');
+	foreach my $prop (@properties_to_check) {
+		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop ''";
+		open my $fh_p, "$check_prop_cmd 2>&1 |";
+		my $output_p = <$fh_p>;
+		close $fh_p;
+
+		if ($output_p !~ /^\Qbad property list: invalid property\E/) {
+			push @{$host_zfs_get_features{$host}->{supported_properties}}, $prop;
+		}
+	}
+
+	writelog('DEBUG', "Host \"$host\" ZFS properties: @{$host_zfs_get_features{$host}->{supported_properties}}");
+
+	return $host_zfs_get_features{$host};
+}
+
+
 sub iszfsbusy {
 	my ($rhost,$fs,$isroot) = @_;
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
@@ -1869,12 +1914,10 @@ sub dumphash() {
 }
 
 sub getsnaps {
-	my ($type,$rhost,$fs,$isroot,$use_fallback,%snaps) = @_;
+	my ($type,$rhost,$fs,$isroot,%snaps) = @_;
 	my $mysudocmd;
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-
-	my $rhostOriginal = $rhost;
 
 	if ($rhost ne '') {
 		$rhost = "$sshcmd $rhost";
@@ -1882,9 +1925,17 @@ sub getsnaps {
 		$fsescaped = escapeshellparam($fsescaped);
 	}
 
-	my $getsnapcmd = $use_fallback
-		? "$rhost $mysudocmd $zfscmd get -Hpd 1 all $fsescaped"
-		: "$rhost $mysudocmd $zfscmd get -Hpd 1 -t snapshot all $fsescaped";
+	my $host_features = check_zfs_get_features($rhost, $mysudocmd, $zfscmd);
+
+	my @properties = @{$host_features->{supported_properties}};
+	my $type_filter = "";
+	if ($host_features->{supports_type_filter}) {
+		$type_filter = "-t snapshot";
+	} else {
+		push @properties, 'type';
+	}
+	my $properties_string = join(',', @properties);
+	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 $type_filter $properties_string $fsescaped";
 
 	if ($debug) {
 		$getsnapcmd = "$getsnapcmd |";
@@ -1894,13 +1945,7 @@ sub getsnaps {
 	}
 	open FH, $getsnapcmd;
 	my @rawsnaps = <FH>;
-	close FH or do {
-		if (!$use_fallback) {
-			writelog('WARN', "snapshot listing failed, trying fallback command");
-			return getsnaps($type, $rhostOriginal, $fs, $isroot, 1, %snaps);
-		}
-		die "CRITICAL ERROR: snapshots couldn't be listed for $fs (exit code $?)";
-	};
+	close FH or die "CRITICAL ERROR: snapshots couldn't be listed for $fs (exit code $?)";
 
 	my %snap_data;
 	my %creationtimes;
@@ -1938,7 +1983,7 @@ sub getsnaps {
 	}
 
 	for my $snap (keys %snap_data) {
-		if (!$use_fallback || $snap_data{$snap}{'type'} eq 'snapshot') {
+		if (length $type_filter || $snap_data{$snap}{'type'} eq 'snapshot') {
 			$snaps{$type}{$snap}{'guid'} = $snap_data{$snap}{'guid'};
 			$snaps{$type}{$snap}{'createtxg'} = $snap_data{$snap}{'createtxg'};
 			$snaps{$type}{$snap}{'creation'} = $snap_data{$snap}{'creation'};


### PR DESCRIPTION
## Motivation and Context

https://github.com/jimsalterjrs/sanoid/pull/818 only added a functional test for the new feature of sorting snapshots by the `createtxg` property, so it and the existing tests did not catch the following regressions:

### [Slower listing of snapshots' properties](https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2157567968)

From @phreaker0:

> i just noticed a huge performance regression with this PR. Because now all properties are fetched instead of only the needed ones ( all vs guid,creation), I get why because if specifying createtxg it will fail for versions where it isn't supported but I guess we need to check for createtxg support once.
> 
> From one of my datasets:
> 
> $ time zfs get -Hpd 1 -t snapshot all '...' > /dev/null
> 
> real 0m2.642s user 0m0.053s sys 0m2.584s
> 
> $ time zfs get -Hpd 1 -t snapshot guid,creation '...' > /dev/null
> 
> real 0m0.804s user 0m0.029s sys 0m0.759s

### [`getsnaps` fallback fails due to the wrong argument being passed in](https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2164155867)

From @Deltik:

> An oversight during [the merging of subroutine `getsnapsfallback` into `getsnaps`](https://github.com/jimsalterjrs/sanoid/pull/818/commits/e301b5b153a33d37f0ab062a90531226a718e1a4) caused the recursive call to prepend `$sshcmd` to `$rhost` again, leading to this error:
> ```shell
> # syncoid --debug root@192.168.122.26:rpool/before syncoid-test-11/after
> … [TRUNCATED] …
> WARNING: snapshot listing failed, trying fallback command
> DEBUG: getting list of snapshots on rpool/before using ssh      ssh      -S   /tmp/syncoid-root19216812226-1718239169-761069-2198 root@192.168.122.26  zfs get -Hpd 1   all ''"'"'rpool/before'"'"'' |...
> root@192.168.122.26: Command not found.
> CRITICAL ERROR: snapshots couldn't be listed for rpool/before (exit code 256) at /usr/sbin/syncoid line 1900.
> ```

### [`getsnaps` parsing error in fallback mode due to non-snapshots appearing in the list](https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2164155867)

From @Deltik:

> If that error were fixed, the fallback command would still fail because non-snapshot datasets would be included in the output, leading to this parsing error:
> ```shell
> # syncoid --debug root@192.168.122.26:rpool/before syncoid-test-11/after
> … [TRUNCATED] …
> WARNING: snapshot listing failed, trying fallback command
> DEBUG: getting list of snapshots on rpool/before using ssh      -S   /tmp/syncoid-root19216812226-1718239740-763496-6973 root@192.168.122.26  zfs get -Hpd 1 all ''"'"'rpool/before'"'"'' |...
> CRITICAL ERROR: Unexpected dataset format in rpool/before       type    filesystem      - at /usr/sbin/syncoid line 1914.
> ```

## Description

These three regressions are fixed in three separate commits:

### perf(syncoid): Regression: Bad performance due to `zfs get all`

Return to using `zfs get guid,creation,createtxg` to avoid the performance overhead of `zfs get all`.

There is a per-host global cache to remember:
* if `zfs get` supports the type filter argument, `-t snapshot` and
* which ZFS properties are available.

The feature check introduced by subroutine `check_zfs_get_features` eliminates the need for a `getsnaps` fallback recursion, as there is no longer any guesswork into what features `zfs get` supports.

Fixes: https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2157567968

### fix(syncoid): Regression: Fallback recursion `$rhost` mutated already

An oversight during the merging of subroutine `getsnapsfallback` into `getsnaps` (https://github.com/jimsalterjrs/sanoid/pull/818/commits/e301b5b1) caused the recursive call to prepend `$sshcmd` to `$rhost` again, leading to this error:

```shell
# syncoid --debug root@192.168.122.26:rpool/before syncoid-test-11/after
… [TRUNCATED] …
WARNING: snapshot listing failed, trying fallback command
DEBUG: getting list of snapshots on rpool/before using ssh      ssh      -S   /tmp/syncoid-root19216812226-1718239169-761069-2198 root@192.168.122.26  zfs get -Hpd 1   all ''"'"'rpool/before'"'"'' |...
root@192.168.122.26: Command not found.
CRITICAL ERROR: snapshots couldn't be listed for rpool/before (exit code 256) at /usr/sbin/syncoid line 1900.
```

Fixes: https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2164155867

### fix(syncoid): Regression: `zfs get` parser not compatible with fallback

In the fallback mode, non-snapshot datasets would be included in the output, leading to this parsing error:

```shell
# syncoid --debug root@192.168.122.26:rpool/before syncoid-test-11/after
… [TRUNCATED] …
WARNING: snapshot listing failed, trying fallback command
DEBUG: getting list of snapshots on rpool/before using ssh      -S   /tmp/syncoid-root19216812226-1718239740-763496-6973 root@192.168.122.26  zfs get -Hpd 1 all ''"'"'rpool/before'"'"'' |...
CRITICAL ERROR: Unexpected dataset format in rpool/before       type    filesystem      - at /usr/sbin/syncoid line 1914.
```

Fixes: https://github.com/jimsalterjrs/sanoid/pull/818#issuecomment-2164155867

## How Has This Been Tested?

I haven't managed to figure out an easy way to test `syncoid`'s new reduced feature set detection features in subroutine `check_zfs_get_features`, so I performed manual acceptance tests with a FreeBSD 8.3 machine, which is preloaded with an old version of ZFS that would trigger what was formerly known as [`getsnapsfallback`](https://github.com/jimsalterjrs/sanoid/commit/30fb5aabeb6f545c1879c843cd538ea22caeb94b) because it does not support <code>zfs get <strong>-t snapshot</strong></code>.

I created some dummy snapshots:

```shell
freebsd# zfs list -rtall
NAME                                                               USED  AVAIL  REFER  MOUNTPOINT
rpool                                                              174K   644M    32K  /rpool
rpool/before                                                        31K   644M    31K  /rpool/before
rpool/before@this-snapshot-should-make-it-into-the-after-dataset      0      -    31K  -
rpool/before@oldest-snapshot                                          0      -    31K  -
rpool/before@another-snapshot-does-not-matter                         0      -    31K  -
```

And then was able to `syncoid` them out:

```
root@workstation:~# syncoid --debug root@192.168.122.26:rpool/before syncoid-test-11/after
DEBUG: SSHCMD: ssh     
Warning: Permanently added '192.168.122.26' (RSA) to the list of known hosts.
DEBUG: checking availability of lzop on source...
DEBUG: checking availability of lzop on target...
DEBUG: checking availability of lzop on local machine...
WARNING: lzop not available on source ssh:-S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26- sync will continue without compression.
DEBUG: checking availability of mbuffer on source...
WARNING: mbuffer not available on source ssh:-S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26 - sync will continue without source buffering.
DEBUG: checking availability of mbuffer on target...
DEBUG: checking availability of pv on local machine...
DEBUG: checking availability of zfs resume feature on source...
DEBUG: checking availability of zfs resume feature on target...
WARNING: ZFS resume feature not available on source machine - sync will continue without resume support.
DEBUG: syncing source rpool/before to target syncoid-test-11/after.
DEBUG: getting current value of syncoid:sync on rpool/before...
DEBUG: ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26  zfs get -H syncoid:sync ''"'"'rpool/before'"'"''
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
DEBUG: checking to see if target filesystem exists using "  zfs get -H name 'syncoid-test-11/after' 2>&1 |"...
DEBUG: Checking `zfs get` features on host "root@192.168.122.26"...
DEBUG: Host "root@192.168.122.26" has `zfs get -t`?: 0
DEBUG: Host "root@192.168.122.26" ZFS properties: guid creation createtxg
DEBUG: getting list of snapshots on rpool/before using ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26  zfs get -Hpd 1  guid,creation,createtxg,type ''"'"'rpool/before'"'"'' |...
DEBUG: creating sync snapshot using "ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26  zfs snapshot ''"'"'rpool/before'"'"''@syncoid_workstation.wizard2.net_2024-06-12:23:45:49-GMT-05:00
"...
DEBUG: target syncoid-test-11/after does not exist.  Finding oldest available snapshot on source rpool/before ...
DEBUG: getting estimated transfer size from source -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26 using "ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26  zfs send  -nvP ''"'"'rpool/before@this-snapshot-should-make-it-into-the-after-dataset'"'"'' 2>&1 |"...
DEBUG: sendsize = 15872
INFO: Sending oldest full snapshot root@192.168.122.26:rpool/before@this-snapshot-should-make-it-into-the-after-dataset to new target filesystem syncoid-test-11/after (~ 15 KB):
DEBUG: sync size: ~15 KB
DEBUG: ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26 ' zfs send  '"'"'rpool/before'"'"'@'"'"'this-snapshot-should-make-it-into-the-after-dataset'"'"'' | mbuffer  -q -s 128k -m 16M | pv -p -t -e -r -b -s 15872 |  zfs receive  -F 'syncoid-test-11/after' 2>&1
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
46.6KiB 0:00:00 [3.98MiB/s] [=============================================================================================================================================================================================================================================] 300%            
DEBUG: getting estimated transfer size from source -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26 using "ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26  zfs send  -nvP -I ''"'"'rpool/before@this-snapshot-should-make-it-into-the-after-dataset'"'"'' ''"'"'rpool/before@syncoid_workstation.wizard2.net_2024-06-12:23:45:49-GMT-05:00'"'"'' 2>&1 |"...
DEBUG: sendsize = 0
INFO: Sending incremental root@192.168.122.26:rpool/before@this-snapshot-should-make-it-into-the-after-dataset ... syncoid_workstation.wizard2.net_2024-06-12:23:45:49-GMT-05:00 to syncoid-test-11/after (~ 4 KB):
DEBUG: sync size: ~4 KB
DEBUG: ssh      -S /tmp/syncoid-root19216812226-1718253948-807483-4632 root@192.168.122.26 ' zfs send  -I '"'"'rpool/before'"'"'@'"'"'this-snapshot-should-make-it-into-the-after-dataset'"'"' '"'"'rpool/before'"'"'@'"'"'syncoid_workstation.wizard2.net_2024-06-12:23:45:49-GMT-05:00'"'"'' | mbuffer  -q -s 128k -m 16M | pv -p -t -e -r -b -s 4096 |  zfs receive  -F 'syncoid-test-11/after' 2>&1
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
2.74KiB 0:00:00 [15.3KiB/s] [================================================================================================================================================================>                                                                            ]  68%            
```

```
root@workstation:~# zfs list -rtall syncoid-test-11/after
NAME                                                                              USED  AVAIL  REFER  MOUNTPOINT
syncoid-test-11/after                                                              23K  23.8M    23K  none
syncoid-test-11/after@this-snapshot-should-make-it-into-the-after-dataset           0B      -    23K  -
syncoid-test-11/after@oldest-snapshot                                               0B      -    23K  -
syncoid-test-11/after@another-snapshot-does-not-matter                              0B      -    23K  -
syncoid-test-11/after@syncoid_workstation.wizard2.net_2024-06-12:23:45:49-GMT-05:00     0B      -    23K  -
```

To test the supported properties detection feature, I added a fake requested property and observed that it was not detected as a supported property:

```diff
diff --git a/syncoid b/syncoid
--- a/syncoid	(revision 8a023d6d7bacb78959e4a5dcab0a1cbf68e84d69)
+++ b/syncoid	(date 1718254080862)
@@ -1421,7 +1421,7 @@
 
 	writelog('DEBUG', "Host \"$host\" has `zfs get -t`?: $rhost_zfs_get_features{$rhost}->{supports_type_filter}");
 
-	my @properties_to_check = ('guid', 'creation', 'createtxg');
+	my @properties_to_check = ('guid', 'creation', 'createtxg', 'notarealprop');
 	foreach my $prop (@properties_to_check) {
 		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop ''";
 		open my $fh_p, "$check_prop_cmd 2>&1 |";
```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)