### PR TITLE
syncoid: add -X send option in special options

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -2175,7 +2175,7 @@ sub parsespecialoptions {
 				return undef;
 			}
 
-			if ($char eq 'o' || $char eq 'x') {
+			if ($char eq 'o' || $char eq 'x' || $char eq 'X') {
 				$lastOption = $char;
 				$optionValue = 1;
 			} else {


### PR DESCRIPTION
-X is listed in allowed options but missing from `parsespecialoptions` so arguments never get parsed. This allows using ZFS native recursive send with excluded datasets.

Been running this for a while with `--sendoptions="Rws X rpool/gentoo/var"` without problems.

```
         -X, --exclude dataset[,dataset]…
             With -R, -X specifies a set of datasets (and, hence, their descendants), to be excluded from the send stream.  The root dataset may not be ex‐
             cluded.  -X a -X b is equivalent to -X a,b.
```