### PR TITLE
ignore duplicate template keys

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -1008,6 +1008,12 @@ sub init {
 					}
 					if ($args{'debug'}) { print "DEBUG: overriding $key on $section with value from user-defined template $template.\n"; }
 					$config{$section}{$key} = $ini{$template}{$key};
+
+					my $value = $config{$section}{$key};
+					if (ref($value) eq 'ARRAY') {
+						# handle duplicates silently (warning was already printed above)
+						$config{$section}{$key} = $value->[0];
+					}
 				}
 			}
 		}


### PR DESCRIPTION
According to the output a duplicate key in the configuration was already handled, but this isn't true for template ones and this leads to wrong behavior with invalid configs.

#952

