### PR TITLE
Syncoid: Allow hostid as argument

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -148,7 +148,7 @@ if (length $args{'hostid'}) {
 		pod2usage(2);
 		exit 127;
 	}
-	$hostid = "$args{'hostid'}_";
+	$hostid = "$args{'hostid'}";
 }
 
 # figure out if source and/or target are remote.


### PR DESCRIPTION
When using an ZFS pool in a multihost configuration, the hostname can change based on where the pool is imported.
Syncoid creates ephemeral snapshot that contains the hostname from where the command is started. When the pool is failover to another machine, the hostname changes and causes to left over ephemeral snapshots from Syncoid on both sides.

Using --no-sync-snap can be a workaround, but in this situation we like to have ephemeral snapshot of Syncoid.

This PR adds the --hostid argument to specifiy a custom hostname / clustername instead. If not specified it will use the hostname.