### PR TITLE
Add disclaimer if using FreeBSD 14.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -162,6 +162,7 @@ Install prerequisite software:
 ```bash
 pkg install p5-Config-Inifiles p5-Capture-Tiny pv mbuffer lzop sanoid
 ```
+_No additional steps are required as of FreeBSD 14.1 - the notes below may apply to versions prior to that._
 
 **Additional notes:**
 


### PR DESCRIPTION
I was able to use initiate `syncoid` successfully from a Debian-based host to a fresh installation of FreeBSD with no configuration changes at all. I hadn't even installed mbuffer or pv - I merely started SSH and was able to replicate right away.

After installing sanoid/syncoid on FreeBSD I found that all the warnings no longer applied: `/usr/local/bin` is the default for all relevant executables and the shebangs were correct.