### PR TITLE
Ability to change snapshot name format

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -17,6 +17,7 @@ use Getopt::Long qw(:config auto_version auto_help);
 use Pod::Usage;       # pod2usage
 use Time::Local;      # to parse dates in reverse
 use Capture::Tiny ':all';
+use POSIX 'strftime';
 
 my %args = (
 	"configdir" => "/etc/sanoid",
@@ -638,7 +639,8 @@ sub take_snapshots {
 			my @snapshots;
 
 			foreach my $type (@types) {
-				my $snapname = "autosnap_$datestamp{'sortable'}_$type";
+				my $sortable = strftime($config{$dataset}{'datestamp_format'}, localtime($datestamp{'unix_time'}));
+				my $snapname = "$config{$dataset}{'prefix'}_${sortable}_$type";
 				push(@snapshots, $snapname);
 			}
 
@@ -947,7 +949,7 @@ sub getsnaps {
 		# avoid pissing off use warnings
 		if (defined $snapname) {
 			my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
-			if ($snapname =~ /^autosnap/) {
+			if ($snapname =~ /^$config{$fs}{'prefix'}/) {
 				$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 				$snaps{$fs}{$snapname}{'type'}=$snaptype;
 			}
@@ -1184,16 +1186,15 @@ sub init {
 
 sub get_date {
 	my %datestamp;
-	($datestamp{'sec'},$datestamp{'min'},$datestamp{'hour'},$datestamp{'mday'},$datestamp{'mon'},$datestamp{'year'},$datestamp{'wday'},$datestamp{'yday'},$datestamp{'isdst'}) = localtime(time);
+	$datestamp{'unix_time'} = time();
+	($datestamp{'sec'},$datestamp{'min'},$datestamp{'hour'},$datestamp{'mday'},$datestamp{'mon'},$datestamp{'year'},$datestamp{'wday'},$datestamp{'yday'},$datestamp{'isdst'}) = localtime($datestamp{'unix_time'});
+
 	$datestamp{'year'} += 1900;
-	$datestamp{'unix_time'} = (((((((($datestamp{'year'} - 1971) * 365) + $datestamp{'yday'}) * 24) + $datestamp{'hour'}) * 60) + $datestamp{'min'}) * 60) + $datestamp{'sec'};
 	$datestamp{'sec'} = sprintf ("%02u", $datestamp{'sec'});
 	$datestamp{'min'} = sprintf ("%02u", $datestamp{'min'});
 	$datestamp{'hour'} = sprintf ("%02u", $datestamp{'hour'});
 	$datestamp{'mday'} = sprintf ("%02u", $datestamp{'mday'});
 	$datestamp{'mon'} = sprintf ("%02u", ($datestamp{'mon'} + 1));
-	$datestamp{'noseconds'} = "$datestamp{'year'}-$datestamp{'mon'}-$datestamp{'mday'}_$datestamp{'hour'}:$datestamp{'min'}";
-	$datestamp{'sortable'} = "$datestamp{'noseconds'}:$datestamp{'sec'}";
 	return %datestamp;
 }
 

--- a/sanoid
+++ b/sanoid
@@ -640,7 +640,10 @@ sub take_snapshots {
 
 			foreach my $type (@types) {
 				my $sortable = strftime($config{$dataset}{'datestamp_format'}, localtime($datestamp{'unix_time'}));
-				my $snapname = "$config{$dataset}{'prefix'}_${sortable}_$type";
+				my $snapname = $config{$dataset}{'snapname_format'};
+				$snapname =~ s/IDENTIFIER/$config{$dataset}{'identifier'}/g;
+				$snapname =~ s/DATE/$sortable/g;
+				$snapname =~ s/TYPE/$type/g;
 				push(@snapshots, $snapname);
 			}
 
@@ -944,12 +947,13 @@ sub getsnaps {
 	}
 
 	foreach my $snap (@rawsnaps) {
-		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*ly)\t*creation\t*(\d*)/);
+		my ($fs,$snapname,$snapdate) = ($snap =~ m/(.*)\@(.*?)\t*creation\t*(\d*)/);
 
 		# avoid pissing off use warnings
 		if (defined $snapname) {
-			my ($snaptype) = ($snapname =~ m/.*_(\w*ly)/);
-			if ($snapname =~ /^$config{$fs}{'prefix'}/) {
+			if ($snapname =~ /$config{$fs}{'identifier'}/) {
+				my @types = qw(yearly monthly weekly daily hourly frequently);
+				my ($snaptype) = grep { $snapname =~ /$_/ } @types;
 				$snaps{$fs}{$snapname}{'ctime'}=$snapdate;
 				$snaps{$fs}{$snapname}{'type'}=$snaptype;
 			}

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -113,3 +113,8 @@ yearly_crit = 0
 # for overriding these values one needs to specify them in a root pool section! ([tank]\n ...)
 capacity_warn = 80
 capacity_crit = 95
+
+# snapshot name formats can be overridden to some extent
+prefix = autosnap
+# strftime-style format string
+datestamp_format = %Y-%m-%d_%H:%M:%S

--- a/sanoid.defaults.conf
+++ b/sanoid.defaults.conf
@@ -114,7 +114,8 @@ yearly_crit = 0
 capacity_warn = 80
 capacity_crit = 95
 
-# snapshot name formats can be overridden to some extent
-prefix = autosnap
+# snapshot name formats can be overridden
+identifier = autosnap
 # strftime-style format string
 datestamp_format = %Y-%m-%d_%H:%M:%S
+snapname_format = IDENTIFIER_DATE_TYPE


### PR DESCRIPTION
This should address everyone's requests from #552, succinctly summed up by @ams-tschoening:

> * custom prefix and suffix
>   * e.g. replace `autosnap` with some custom wording
>   * e.g. move labels like `frequently` to the front
> * custom format of timestamps
>   * e.g. to remove `:`
>   * e.g. to make format overall shorter, e.g. `@autosnap_20230303T203610Z_weekly`
> * maintain formats in the config file
>   * templates + overrides per dataset would be great
>   * I put config files those under version control mostly

The new properties can be overridden for child datasets if the parent uses `recursive = yes`. I've tested a few different configurations and everything seems to be working as expected. The first commit here covers everything except reordering the substrings with a user-defined template.

I separated that into a second commit since it requires more invasive changes to `getsnaps()`. The old behavior expects snap names to start with `autosnap` and end with a `*ly` type. The new behavior recognizes sanoid autosnaps as long as the name contains both a `*ly` type and whatever identifier string the dataset is configured to use, which defaults to `autosnap`.

There is currently no tracking of old identifier labels after they've been changed, but the only person who mentioned that possibility said they didn't need it.