### PR TITLE
syncoid: fix directtimeout in directmbuffer mode

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -178,7 +178,7 @@ if (length $args{'insecure-direct-connection'}) {
 		$directlisten = $args{'insecure-direct-connection'};
 	}
 
-	if (scalar @parts == 3) {
+	if (scalar @parts >= 3) {
 		$directtimeout = $parts[2];
 	}
 


### PR DESCRIPTION
If --insecure-direct-connection contained 4 parts (including the ',mbuffer' at the end), the 3rd part (timeout) was silently ignored and left at the default 60s.

Do not ignore the timeout part even in directmbuffer mode.