### PR TITLE
Improve zstd concurrency and add a new zstd compression level

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -17,6 +17,9 @@ use Capture::Tiny ':all';
 
 my $mbuffer_size = "16M";
 my $pvoptions = "-p -t -e -r -b";
+# Get number of CPUs for zstd threading, but leave at least two cores empty
+my $ncpus = int(`nproc`);
+if ($ncpus > 2) { $ncpus -= 2;}
 
 # Blank defaults to use ssh client's default
 # TODO: Merge into a single "sshflags" option?
@@ -1142,10 +1145,10 @@ sub compressargset {
 			decomargs   => '-dc',
 		},
 		'zstd-fast' => {
-			rawcmd      => 'zstd',
-			args        => '-3',
-			decomrawcmd => 'zstd',
-			decomargs   => '-dc',
+                        rawcmd      => 'zstd',
+                        args        => "-T$ncpus -3",
+                        decomrawcmd => 'zstd',
+                        decomargs   => "-T$ncpus -dc",
 		},
 		'zstdmt-fast' => {
 			rawcmd      => 'zstdmt',
@@ -1154,10 +1157,10 @@ sub compressargset {
 			decomargs   => '-dc',
 		},
 		'zstd-slow' => {
-			rawcmd      => 'zstd',
-			args        => '-19',
-			decomrawcmd => 'zstd',
-			decomargs   => '-dc',
+                        rawcmd      => 'zstd',
+                        args        => "-T$ncpus -19",
+                        decomrawcmd => 'zstd',
+                        decomargs   => "-T$ncpus -dc",
 		},
 		'zstdmt-slow' => {
 			rawcmd      => 'zstdmt',

--- a/syncoid
+++ b/syncoid
@@ -17,7 +17,7 @@ use Capture::Tiny ':all';
 
 my $mbuffer_size = "16M";
 my $pvoptions = "-p -t -e -r -b";
-# Get number of CPUs for zstd threading, but leave at least two cores empty
+# Get number of CPUs for zstd threading, but leave at least two cores empty for system responsiveness
 my $ncpus = int(`nproc`);
 if ($ncpus > 2) { $ncpus -= 2;}
 

--- a/syncoid
+++ b/syncoid
@@ -1150,6 +1150,12 @@ sub compressargset {
                         decomrawcmd => 'zstd',
                         decomargs   => "-T$ncpus -dc",
 		},
+		'zstd-medium' => {
+                        rawcmd      => 'zstd',
+                        args        => "-T$ncpus -8",
+                        decomrawcmd => 'zstd',
+                        decomargs   => "-T$ncpus -dc",
+		},
 		'zstdmt-fast' => {
 			rawcmd      => 'zstdmt',
 			args        => '-3',
@@ -1190,7 +1196,7 @@ sub compressargset {
 
 	if ($value eq 'default') {
 		$value = $DEFAULT_COMPRESSION;
-	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'zstd-fast', 'zstdmt-fast', 'zstd-slow', 'zstdmt-slow', 'lz4', 'xz', 'lzo', 'default', 'none'))) {
+	} elsif (!(grep $value eq $_, ('gzip', 'pigz-fast', 'pigz-slow', 'zstd-fast', 'zstd-medium', 'zstdmt-fast', 'zstd-slow', 'zstdmt-slow', 'lz4', 'xz', 'lzo', 'default', 'none'))) {
 		writelog('WARN', "Unrecognised compression value $value, defaulting to $DEFAULT_COMPRESSION");
 		$value = $DEFAULT_COMPRESSION;
 	}
@@ -2323,7 +2329,7 @@ syncoid - ZFS snapshot replication tool
 
 Options:
 
-  --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, zstd-fast, zstdmt-fast, zstd-slow, zstdmt-slow, lz4, xz, lzo (default) & none
+  --compress=FORMAT     Compresses data during transfer. Currently accepted options are gzip, pigz-fast, pigz-slow, zstd-fast, zstd-medium, zstdmt-fast, zstd-slow, zstdmt-slow, lz4, xz, lzo (default) & none
   --identifier=EXTRA    Extra identifier which is included in the snapshot name. Can be used for replicating to multiple targets.
   --recursive|r         Also transfers child datasets
   --skip-parent         Skips syncing of the parent dataset. Does nothing without '--recursive' option.


### PR DESCRIPTION
When using syncoid `zstd-slow` compression for maximal bandwidth savings, I noticed that I got about 2-4MB/s instead of roughly 30MB/s with `zstd-fast`.
After a quick check, I noticed that zstd wasn't run with threading option, so `zstd-slow` was using only one core, making the cpu the bottleneck of replication speed.

This patch checks the local system for the number of cpus, and sets zstd to use as much cores as possible except two cores, in order to not overload the system.

Also, on my 80 core system, `zstd-slow` still reduces overall replication performance by a magnitude of 10, for a system load increase of about 30, so I added `zstd-medium`.
According to the following (quick and dirty) benchmark, I configured `zstd-medium` to level 8, which looks like a good sweetspot between cpu usage and throughput.


```
curl -o /tmp/lorem.txt http://metaphorpsum.com/paragraphs/30
zstd -T0 -b1 -e22 /tmp/lorem.txt

 1#lorem.txt         :      5164 ->      2169 (x2.381),  167.1 MB/s   397.4 MB/s
 2#lorem.txt         :      5164 ->      2222 (x2.324),  143.4 MB/s,  337.0 MB/s
 3#lorem.txt         :      5164 ->      2146 (x2.406),  115.4 MB/s,  363.0 MB/s
 4#lorem.txt         :      5164 ->      2114 (x2.443),   59.4 MB/s,  358.3 MB/s
 5#lorem.txt         :      5164 ->      2100 (x2.459),   44.9 MB/s,  364.5 MB/s
 6#lorem.txt         :      5164 ->      2083 (x2.479),   38.9 MB/s,  370.5 MB/s
 7#lorem.txt         :      5164 ->      2081 (x2.481),   38.4 MB/s,  371.9 MB/s
 8#lorem.txt         :      5164 ->      2081 (x2.481),   38.4 MB/s,  371.6 MB/s
 9#lorem.txt         :      5164 ->      2081 (x2.481),   21.8 MB/s,  372.0 MB/s
10#lorem.txt         :      5164 ->      2081 (x2.481),   21.8 MB/s,  371.6 MB/s
11#lorem.txt         :      5164 ->      2070 (x2.495),   11.7 MB/s,  386.6 MB/s
12#lorem.txt         :      5164 ->      2070 (x2.495),   8.46 MB/s,  383.2 MB/s
13#lorem.txt         :      5164 ->      2065 (x2.501),   6.60 MB/s,  374.4 MB/s
14#lorem.txt         :      5164 ->      2065 (x2.501),   5.96 MB/s,  374.6 MB/s
15#lorem.txt         :      5164 ->      2065 (x2.501),   5.94 MB/s,  373.8 MB/s
16#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  372.3 MB/s
17#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  372.0 MB/s
18#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  371.7 MB/s
19#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  371.6 MB/s
20#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  371.8 MB/s
21#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  371.7 MB/s
22#lorem.txt         :      5164 ->      2064 (x2.502),   3.03 MB/s,  372.1 MB/s
```