### PR TITLE
syncoid: Sort snapshots by `createtxg` if possible (fallback to `creation`) (redux of #818)

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -441,7 +441,7 @@ sub syncdataset {
 			# Don't send the sync snap if it's filtered out by --exclude-snaps or
 			# --include-snaps
 			if (!snapisincluded($newsyncsnap)) {
-				$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
+				$newsyncsnap = getnewestsnapshot(\%snaps);
 				if ($newsyncsnap eq 0) {
 					writelog('WARN', "CRITICAL: no snapshots exist on source $sourcefs, and you asked for --no-sync-snap.");
 					if ($exitcode < 1) { $exitcode = 1; }
@@ -450,7 +450,7 @@ sub syncdataset {
 			}
 		} else {
 			# we don't want sync snapshots created, so use the newest snapshot we can find.
-			$newsyncsnap = getnewestsnapshot($sourcehost,$sourcefs,$sourceisroot);
+			$newsyncsnap = getnewestsnapshot(\%snaps);
 			if ($newsyncsnap eq 0) {
 				writelog('WARN', "CRITICAL: no snapshots exist on source $sourcefs, and you asked for --no-sync-snap.");
 				if ($exitcode < 1) { $exitcode = 1; }
@@ -868,7 +868,7 @@ sub syncdataset {
 			%snaps = (%sourcesnaps, %targetsnaps);
 		}
 
-		my @to_delete = sort { $snaps{'target'}{$a}{'creation'}<=>$snaps{'target'}{$b}{'creation'} } grep {!exists $snaps{'source'}{$_}} keys %{ $snaps{'target'} };
+		my @to_delete = sort { sortsnapshots($snaps{'target'}, $a, $b) } grep {!exists $snaps{'source'}{$_}} keys %{ $snaps{'target'} };
 		while (@to_delete) {
 			# Create batch of snapshots to remove
 			my $snaps = join ',', splice(@to_delete, 0, 50);
@@ -1574,9 +1574,22 @@ sub readablebytes {
 	return $disp;
 }
 
+sub sortsnapshots {
+	my ($snapdata, $left, $right) = @_;
+	if (defined $snapdata->{$left}{'createtxg'} && defined $snapdata->{$right}{'createtxg'}) {
+		return $snapdata->{$left}{'createtxg'} <=> $snapdata->{$right}{'createtxg'};
+	}
+
+	if (defined $snapdata->{$left}{'creation'} && defined $snapdata->{$right}{'creation'}) {
+		return $snapdata->{$left}{'creation'} <=> $snapdata->{$right}{'creation'};
+	}
+
+	return 0;
+}
+
 sub getoldestsnapshot {
 	my $snaps = shift;
-	foreach my $snap ( sort { $snaps{'source'}{$a}{'creation'}<=>$snaps{'source'}{$b}{'creation'} } keys %{ $snaps{'source'} }) {
+	foreach my $snap (sort { sortsnapshots($snaps{'source'}, $a, $b) } keys %{ $snaps{'source'} }) {
 		# return on first snap found - it's the oldest
 		return $snap;
 	}
@@ -1590,7 +1603,7 @@ sub getoldestsnapshot {
 
 sub getnewestsnapshot {
 	my $snaps = shift;
-	foreach my $snap ( sort { $snaps{'source'}{$b}{'creation'}<=>$snaps{'source'}{$a}{'creation'} } keys %{ $snaps{'source'} }) {
+	foreach my $snap (sort { sortsnapshots($snaps{'source'}, $b, $a) } keys %{ $snaps{'source'} }) {
 		# return on first snap found - it's the newest
 		writelog('DEBUG', "NEWEST SNAPSHOT: $snap");
 		return $snap;
@@ -1769,7 +1782,7 @@ sub pruneoldsyncsnaps {
 
 sub getmatchingsnapshot {
 	my ($sourcefs, $targetfs, $snaps) = @_;
-	foreach my $snap ( sort { $snaps{'source'}{$b}{'creation'}<=>$snaps{'source'}{$a}{'creation'} } keys %{ $snaps{'source'} }) {
+	foreach my $snap ( sort { sortsnapshots($snaps{'source'}, $b, $a) } keys %{ $snaps{'source'} }) {
 		if (defined $snaps{'target'}{$snap}) {
 			if ($snaps{'source'}{$snap}{'guid'} == $snaps{'target'}{$snap}{'guid'}) {
 				return $snap;
@@ -1974,9 +1987,11 @@ sub getsnaps {
 
 	for my $snap (keys %snap_data) {
 		if (length $type_filter || $snap_data{$snap}{'type'} eq 'snapshot') {
-			$snaps{$type}{$snap}{'guid'} = $snap_data{$snap}{'guid'};
-			$snaps{$type}{$snap}{'createtxg'} = $snap_data{$snap}{'createtxg'};
-			$snaps{$type}{$snap}{'creation'} = $snap_data{$snap}{'creation'};
+			foreach my $prop (@{$host_features->{supported_properties}}) {
+				if (exists $snap_data{$snap}{$prop}) {
+					$snaps{$type}{$snap}{$prop} = $snap_data{$snap}{$prop};
+				}
+			}
 		}
 	}
 

--- a/syncoid
+++ b/syncoid
@@ -194,6 +194,9 @@ if (length $args{'insecure-direct-connection'}) {
 # warn user of anything missing, then continue with sync.
 my %avail = checkcommands();
 
+# host => { supports_type_filter => 1/0, supported_properties => ['guid', 'creation', ...] }
+my %host_zfs_get_features;
+
 my %snaps;
 my $exitcode = 0;
 
@@ -1392,6 +1395,47 @@ sub checkcommands {
 	return %avail;
 }
 
+sub check_zfs_get_features {
+	my ($rhost, $mysudocmd, $zfscmd) = @_;
+	my $host = $rhost ? (split(/\s+/, $rhost))[-1] : "localhost";
+
+	return $host_zfs_get_features{$host} if exists $host_zfs_get_features{$host};
+
+	writelog('DEBUG', "Checking `zfs get` features on host \"$host\"...");
+
+	$host_zfs_get_features{$host} = {
+		supports_type_filter => 0,
+		supported_properties => ['guid', 'creation']
+	};
+
+	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot '' ''";
+	open my $fh_t, "$check_t_option_cmd 2>&1 |";
+	my $output_t = <$fh_t>;
+	close $fh_t;
+
+	if ($output_t !~ /^\Qinvalid option\E/) {
+		$host_zfs_get_features{$host}->{supports_type_filter} = 1;
+	}
+
+	writelog('DEBUG', "Host \"$host\" has `zfs get -t`?: $host_zfs_get_features{$host}->{supports_type_filter}");
+
+	my @properties_to_check = ('createtxg');
+	foreach my $prop (@properties_to_check) {
+		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop ''";
+		open my $fh_p, "$check_prop_cmd 2>&1 |";
+		my $output_p = <$fh_p>;
+		close $fh_p;
+
+		if ($output_p !~ /^\Qbad property list: invalid property\E/) {
+			push @{$host_zfs_get_features{$host}->{supported_properties}}, $prop;
+		}
+	}
+
+	writelog('DEBUG', "Host \"$host\" ZFS properties: @{$host_zfs_get_features{$host}->{supported_properties}}");
+
+	return $host_zfs_get_features{$host};
+}
+
 sub iszfsbusy {
 	my ($rhost,$fs,$isroot) = @_;
 	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
@@ -1860,13 +1904,11 @@ sub dumphash() {
 	writelog('INFO', Dumper($hash));
 }
 
-sub getsnaps() {
+sub getsnaps {
 	my ($type,$rhost,$fs,$isroot,%snaps) = @_;
 	my $mysudocmd;
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-
-	my $rhostOriginal = $rhost;
 
 	if ($rhost ne '') {
 		$rhost = "$sshcmd $rhost";
@@ -1874,7 +1916,18 @@ sub getsnaps() {
 		$fsescaped = escapeshellparam($fsescaped);
 	}
 
-	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t snapshot guid,creation $fsescaped";
+	my $host_features = check_zfs_get_features($rhost, $mysudocmd, $zfscmd);
+
+	my @properties = @{$host_features->{supported_properties}};
+	my $type_filter = "";
+	if ($host_features->{supports_type_filter}) {
+		$type_filter = "-t snapshot";
+	} else {
+		push @properties, 'type';
+	}
+	my $properties_string = join(',', @properties);
+	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 $type_filter $properties_string $fsescaped";
+
 	if ($debug) {
 		$getsnapcmd = "$getsnapcmd |";
 		writelog('DEBUG', "getting list of snapshots on $fs using $getsnapcmd...");
@@ -1883,142 +1936,48 @@ sub getsnaps() {
 	}
 	open FH, $getsnapcmd;
 	my @rawsnaps = <FH>;
-	close FH or do {
-		# fallback (solaris for example doesn't support the -t option)
-		return getsnapsfallback($type,$rhostOriginal,$fs,$isroot,%snaps);
-	};
-
-	# this is a little obnoxious. get guid,creation returns guid,creation on two separate lines
-	# as though each were an entirely separate get command.
-
-	my %creationtimes=();
-
-	foreach my $line (@rawsnaps) {
-		$line =~ /\Q$fs\E\@(\S*)/;
-		my $snapname = $1;
-
-		if (!snapisincluded($snapname)) { next; }
-
-		# only import snap guids from the specified filesystem
-		if ($line =~ /\Q$fs\E\@.*\tguid/) {
-			chomp $line;
-			my $guid = $line;
-			$guid =~ s/^.*\tguid\t*(\d*).*/$1/;
-			my $snap = $line;
-			$snap =~ s/^.*\@(.*)\tguid.*$/$1/;
-			$snaps{$type}{$snap}{'guid'}=$guid;
-		}
-		# only import snap creations from the specified filesystem
-		elsif ($line =~ /\Q$fs\E\@.*\tcreation/) {
-			chomp $line;
-			my $creation = $line;
-			$creation =~ s/^.*\tcreation\t*(\d*).*/$1/;
-			my $snap = $line;
-			$snap =~ s/^.*\@(.*)\tcreation.*$/$1/;
-
-			# the accuracy of the creation timestamp is only for a second, but
-			# snapshots in the same second are highly likely. The list command
-			# has an ordered output so we append another three digit running number
-			# to the creation timestamp and make sure those are ordered correctly
-			# for snapshot with the same creation timestamp
-			my $counter = 0;
-			my $creationsuffix;
-			while ($counter < 999) {
-				$creationsuffix = sprintf("%s%03d", $creation, $counter);
-				if (!defined $creationtimes{$creationsuffix}) {
-					$creationtimes{$creationsuffix} = 1;
-					last;
-				}
-				$counter += 1;
-			}
-
-			$snaps{$type}{$snap}{'creation'}=$creationsuffix;
-		}
-	}
-
-	return %snaps;
-}
-
-sub getsnapsfallback() {
-	# fallback (solaris for example doesn't support the -t option)
-	my ($type,$rhost,$fs,$isroot,%snaps) = @_;
-	my $mysudocmd;
-	my $fsescaped = escapeshellparam($fs);
-	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
-	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 type,guid,creation $fsescaped |";
-	writelog('WARN', "snapshot listing failed, trying fallback command");
-	writelog('DEBUG', "FALLBACK, getting list of snapshots on $fs using $getsnapcmd...");
-	open FH, $getsnapcmd;
-	my @rawsnaps = <FH>;
 	close FH or die "CRITICAL ERROR: snapshots couldn't be listed for $fs (exit code $?)";
 
-	my %creationtimes=();
+	my %snap_data;
+	my %creationtimes;
 
-	my $state = 0;
-	foreach my $line (@rawsnaps) {
-		if ($state < 0) {
-			$state++;
-			next;
-		}
+	for my $line (@rawsnaps) {
+		chomp $line;
+		my ($dataset, $property, $value) = split /\t/, $line;
+		next unless defined $value;
 
-		if ($state eq 0) {
-			if ($line !~ /\Q$fs\E\@.*\ttype\s*snapshot/) {
-				# skip non snapshot type object
-				$state = -2;
-				next;
-			}
-		} elsif ($state eq 1) {
-			if ($line !~ /\Q$fs\E\@.*\tguid/) {
-				die "CRITICAL ERROR: snapshots couldn't be listed for $fs (guid parser error)";
-			}
+		my (undef, $snap) = split /@/, $dataset;
+		next unless length $snap;
 
-			chomp $line;
-			my $guid = $line;
-			$guid =~ s/^.*\tguid\t*(\d*).*/$1/;
-			my $snap = $line;
-			$snap =~ s/^.*\@(.*)\tguid.*$/$1/;
-			if (!snapisincluded($snap)) { next; }
-			$snaps{$type}{$snap}{'guid'}=$guid;
-		} elsif ($state eq 2) {
-			if ($line !~ /\Q$fs\E\@.*\tcreation/) {
-				die "CRITICAL ERROR: snapshots couldn't be listed for $fs (creation parser error)";
-			}
+		if (!snapisincluded($snap)) { next; }
+		$snap_data{$snap}{$property} = $value;
 
-			chomp $line;
-			my $creation = $line;
-			$creation =~ s/^.*\tcreation\t*(\d*).*/$1/;
-			my $snap = $line;
-			$snap =~ s/^.*\@(.*)\tcreation.*$/$1/;
-			if (!snapisincluded($snap)) { next; }
-
-			# the accuracy of the creation timestamp is only for a second, but
-			# snapshots in the same second are highly likely. The list command
-			# has an ordered output so we append another three digit running number
-			# to the creation timestamp and make sure those are ordered correctly
-			# for snapshot with the same creation timestamp
+		# the accuracy of the creation timestamp is only for a second, but
+		# snapshots in the same second are highly likely. The list command
+		# has an ordered output so we append another three digit running number
+		# to the creation timestamp and make sure those are ordered correctly
+		# for snapshot with the same creation timestamp
+		if ($property eq 'creation') {
 			my $counter = 0;
 			my $creationsuffix;
 			while ($counter < 999) {
-				$creationsuffix = sprintf("%s%03d", $creation, $counter);
+				$creationsuffix = sprintf("%s%03d", $value, $counter);
 				if (!defined $creationtimes{$creationsuffix}) {
 					$creationtimes{$creationsuffix} = 1;
 					last;
 				}
 				$counter += 1;
 			}
-
-			$snaps{$type}{$snap}{'creation'}=$creationsuffix;
-			$state = -1;
+			$snap_data{$snap}{'creation'} = $creationsuffix;
 		}
+	}
 
-		$state++;
+	for my $snap (keys %snap_data) {
+		if (length $type_filter || $snap_data{$snap}{'type'} eq 'snapshot') {
+			$snaps{$type}{$snap}{'guid'} = $snap_data{$snap}{'guid'};
+			$snaps{$type}{$snap}{'createtxg'} = $snap_data{$snap}{'createtxg'};
+			$snaps{$type}{$snap}{'creation'} = $snap_data{$snap}{'creation'};
+		}
 	}
 
 	return %snaps;
@@ -2036,8 +1995,12 @@ sub getbookmarks() {
 		$fsescaped = escapeshellparam($fsescaped);
 	}
 
+	my $host_features = check_zfs_get_features($rhost, $mysudocmd, $zfscmd);
+	my @properties = @{$host_features->{supported_properties}};
+	my $properties_string = join(',', @properties);
+
 	my $error = 0;
-	my $getbookmarkcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t bookmark guid,creation $fsescaped 2>&1 |";
+	my $getbookmarkcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t bookmark $properties_string $fsescaped 2>&1 |";
 	writelog('DEBUG', "getting list of bookmarks on $fs using $getbookmarkcmd...");
 	open FH, $getbookmarkcmd;
 	my @rawbookmarks = <FH>;
@@ -2052,46 +2015,44 @@ sub getbookmarks() {
 		die "CRITICAL ERROR: bookmarks couldn't be listed for $fs (exit code $?)";
 	}
 
-	# this is a little obnoxious. get guid,creation returns guid,creation on two separate lines
-	# as though each were an entirely separate get command.
+	my %bookmark_data;
+	my %creationtimes;
 
-	my $lastguid;
-	my %creationtimes=();
+	for my $line (@rawbookmarks) {
+		chomp $line;
+		my ($dataset, $property, $value) = split /\t/, $line;
+		next unless defined $value;
 
-	foreach my $line (@rawbookmarks) {
-		# only import bookmark guids, creation from the specified filesystem
-		if ($line =~ /\Q$fs\E\#.*\tguid/) {
-			chomp $line;
-			$lastguid = $line;
-			$lastguid =~ s/^.*\tguid\t*(\d*).*/$1/;
-			my $bookmark = $line;
-			$bookmark =~ s/^.*\#(.*)\tguid.*$/$1/;
-			$bookmarks{$lastguid}{'name'}=$bookmark;
-		} elsif ($line =~ /\Q$fs\E\#.*\tcreation/) {
-			chomp $line;
-			my $creation = $line;
-			$creation =~ s/^.*\tcreation\t*(\d*).*/$1/;
-			my $bookmark = $line;
-			$bookmark =~ s/^.*\#(.*)\tcreation.*$/$1/;
+		my (undef, $bookmark) = split /#/, $dataset;
+		next unless length $bookmark;
 
-			# the accuracy of the creation timestamp is only for a second, but
-			# bookmarks in the same second are possible. The list command
-			# has an ordered output so we append another three digit running number
-			# to the creation timestamp and make sure those are ordered correctly
-			# for bookmarks with the same creation timestamp
+		$bookmark_data{$bookmark}{$property} = $value;
+
+		# the accuracy of the creation timestamp is only for a second, but
+		# bookmarks in the same second are possible. The list command
+		# has an ordered output so we append another three digit running number
+		# to the creation timestamp and make sure those are ordered correctly
+		# for bookmarks with the same creation timestamp
+		if ($property eq 'creation') {
 			my $counter = 0;
 			my $creationsuffix;
 			while ($counter < 999) {
-				$creationsuffix = sprintf("%s%03d", $creation, $counter);
+				$creationsuffix = sprintf("%s%03d", $value, $counter);
 				if (!defined $creationtimes{$creationsuffix}) {
 					$creationtimes{$creationsuffix} = 1;
 					last;
 				}
 				$counter += 1;
 			}
-
-			$bookmarks{$lastguid}{'creation'}=$creationsuffix;
+			$bookmark_data{$bookmark}{'creation'} = $creationsuffix;
 		}
+	}
+
+	for my $bookmark (keys %bookmark_data) {
+		my $guid = $bookmark_data{$bookmark}{'guid'};
+		$bookmarks{$guid}{'name'} = $bookmark;
+		$bookmarks{$guid}{'creation'} = $bookmark_data{$bookmark}{'creation'};
+		$bookmarks{$guid}{'createtxg'} = $bookmark_data{$bookmark}{'createtxg'};
 	}
 
 	return %bookmarks;

--- a/syncoid
+++ b/syncoid
@@ -578,28 +578,26 @@ sub syncdataset {
 
 		my $targetsize = getzfsvalue($targethost,$targetfs,$targetisroot,'-p used');
 
-		my $bookmark = 0;
-		my $bookmarkcreation = 0;
+		my %bookmark = ();
 
 		$matchingsnap = getmatchingsnapshot($sourcefs, $targetfs, \%snaps);
 		if (! $matchingsnap) {
 			# no matching snapshots, check for bookmarks as fallback
 			my %bookmarks = getbookmarks($sourcehost,$sourcefs,$sourceisroot);
 
-			# check for matching guid of source bookmark and target snapshot (oldest first)
-			foreach my $snap ( sort { $snaps{'target'}{$b}{'creation'}<=>$snaps{'target'}{$a}{'creation'} } keys %{ $snaps{'target'} }) {
+			# check for matching guid of source bookmark and target snapshot (newest first)
+			foreach my $snap ( sort { sortsnapshots($snaps{'target'}, $b, $a) } keys %{ $snaps{'target'} }) {
 				my $guid = $snaps{'target'}{$snap}{'guid'};
 
 				if (defined $bookmarks{$guid}) {
 					# found a match
-					$bookmark = $bookmarks{$guid}{'name'};
-					$bookmarkcreation = $bookmarks{$guid}{'creation'};
+					%bookmark = %{ $bookmarks{$guid} };
 					$matchingsnap = $snap;
 					last;
 				}
 			}
 
-			if (! $bookmark) {
+			if (! %bookmark) {
 				# force delete is not possible for the root dataset
 				if ($args{'force-delete'} && index($targetfs, '/') != -1) {
 					writelog('INFO', "Removing $targetfs because no matching snapshots were found");
@@ -672,15 +670,18 @@ sub syncdataset {
 
 			my $nextsnapshot = 0;
 
-			if ($bookmark) {
-				my $bookmarkescaped = escapeshellparam($bookmark);
+			if (%bookmark) {
 
 				if (!defined $args{'no-stream'}) {
 					# if intermediate snapshots are needed we need to find the next oldest snapshot,
 					# do an replication to it and replicate as always from oldest to newest
 					# because bookmark sends doesn't support intermediates directly
-					foreach my $snap ( sort { $snaps{'source'}{$a}{'creation'}<=>$snaps{'source'}{$b}{'creation'} } keys %{ $snaps{'source'} }) {
-						if ($snaps{'source'}{$snap}{'creation'} >= $bookmarkcreation) {
+					foreach my $snap ( sort { sortsnapshots($snaps{'source'}, $a, $b) } keys %{ $snaps{'source'} }) {
+						my $comparisonkey = 'creation';
+						if (defined $snaps{'source'}{$snap}{'createtxg'} && defined $bookmark{'createtxg'}) {
+							$comparisonkey = 'createtxg';
+						}
+						if ($snaps{'source'}{$snap}{$comparisonkey} >= $bookmark{$comparisonkey}) {
 							$nextsnapshot = $snap;
 							last;
 						}
@@ -688,13 +689,13 @@ sub syncdataset {
 				}
 
 				if ($nextsnapshot) {
-					($exit, $stdout) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark, $nextsnapshot);
+					($exit, $stdout) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark{'name'}, $nextsnapshot);
 
 					$exit == 0 or do {
 						if (!$resume && $stdout =~ /\Qcontains partially-complete state\E/) {
 							writelog('WARN', "resetting partially receive state");
 							resetreceivestate($targethost,$targetfs,$targetisroot);
-							(my $ret) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark, $nextsnapshot);
+							(my $ret) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark{'name'}, $nextsnapshot);
 							$ret == 0 or do {
 								if ($exitcode < 2) { $exitcode = 2; }
 								return 0;
@@ -708,13 +709,13 @@ sub syncdataset {
 					$matchingsnap = $nextsnapshot;
 					$matchingsnapescaped = escapeshellparam($matchingsnap);
 				} else {
-					($exit, $stdout) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark, $newsyncsnap);
+					($exit, $stdout) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark{'name'}, $newsyncsnap);
 
 					$exit == 0 or do {
 						if (!$resume && $stdout =~ /\Qcontains partially-complete state\E/) {
 							writelog('WARN', "resetting partially receive state");
 							resetreceivestate($targethost,$targetfs,$targetisroot);
-							(my $ret) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark, $newsyncsnap);
+							(my $ret) = syncbookmark($sourcehost, $sourcefs, $targethost, $targetfs, $bookmark{'name'}, $newsyncsnap);
 							$ret == 0 or do {
 								if ($exitcode < 2) { $exitcode = 2; }
 								return 0;
@@ -729,7 +730,7 @@ sub syncdataset {
 
 			# do a normal replication if bookmarks aren't used or if previous
 			# bookmark replication was only done to the next oldest snapshot
-			if (!$bookmark || $nextsnapshot) {
+			if (!%bookmark || $nextsnapshot) {
 				if ($matchingsnap eq $newsyncsnap) {
 					# edge case: bookmark replication used the latest snapshot
 					return 0;

--- a/tests/common/lib.sh
+++ b/tests/common/lib.sh
@@ -57,7 +57,7 @@ function disableTimeSync {
 
     which systemctl > /dev/null
     if [ $? -eq 0 ]; then
-        systemctl is-active virtualbox-guest-utils.service && systemctl stop virtualbox-guest-utils.service
+        systemctl is-active virtualbox-guest-utils.service && systemctl stop virtualbox-guest-utils.service || true
     fi
 }
 

--- a/tests/syncoid/011_sync_out-of-order_snapshots/run.sh
+++ b/tests/syncoid/011_sync_out-of-order_snapshots/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# test verifying snapshots with out-of-order snapshot creation datetimes
+
+set -x
+set -e
+
+. ../../common/lib.sh
+
+POOL_IMAGE="/tmp/jimsalterjrs_sanoid_815.img"
+POOL_SIZE="64M"
+POOL_NAME="jimsalterjrs_sanoid_815"
+
+truncate -s "${POOL_SIZE}" "${POOL_IMAGE}"
+
+zpool create -m none -f "${POOL_NAME}" "${POOL_IMAGE}"
+
+function cleanUp {
+  zpool export "${POOL_NAME}"
+  rm -f "${POOL_IMAGE}"
+}
+
+# export pool and remove the image in any case
+trap cleanUp EXIT
+
+zfs create "${POOL_NAME}"/before
+zfs snapshot "${POOL_NAME}"/before@this-snapshot-should-make-it-into-the-after-dataset
+
+disableTimeSync
+setdate 1155533696
+zfs snapshot "${POOL_NAME}"/before@oldest-snapshot
+
+zfs snapshot "${POOL_NAME}"/before@another-snapshot-does-not-matter
+../../../syncoid --sendoptions="Lec" "${POOL_NAME}"/before "${POOL_NAME}"/after
+
+# verify
+saveSnapshotList "${POOL_NAME}" "snapshot-list.txt"
+
+grep "${POOL_NAME}/before@this-snapshot-should-make-it-into-the-after-dataset" "snapshot-list.txt" || exit $?
+grep "${POOL_NAME}/after@this-snapshot-should-make-it-into-the-after-dataset" "snapshot-list.txt" || exit $?
+grep "${POOL_NAME}/before@oldest-snapshot" "snapshot-list.txt" || exit $?
+grep "${POOL_NAME}/after@oldest-snapshot" "snapshot-list.txt" || exit $?
+grep "${POOL_NAME}/before@another-snapshot-does-not-matter" "snapshot-list.txt" || exit $?
+grep "${POOL_NAME}/after@another-snapshot-does-not-matter" "snapshot-list.txt" || exit $?
+
+exit 0


### PR DESCRIPTION
## Motivation and Context

This pull request addresses the same underlying issue as the [reverted](https://github.com/jimsalterjrs/sanoid/commit/b794da6f145fdeb8ff1e48d267629cc51193470c) #818: #815 (_Syncoid: Data loss because getoldestsnapshot() might not choose the first snapshot_).  This remake incorporates the new approach from #931 to avoid the performance regressions and bugs that caused #818 to be reverted in b794da6f145fdeb8ff1e48d267629cc51193470c.

The original problem remains in [Syncoid v2.3.0](https://github.com/jimsalterjrs/sanoid/releases/tag/v2.3.0): When system clocks are adjusted (due to NTP sync, manual changes, etc.), ZFS snapshot `creation` timestamps can become non-monotonic.  This causes `syncoid`'s `getoldestsnapshot()` and `getnewestsnapshot()` functions to select incorrect snapshots, potentially leading to missing data during initial replication or when using `--no-sync-snap`.

## Description

This new implementation reworks the approach taken in #818, addressing both the original issue and the regressions that led to its revert:

### fix(syncoid): Rework snap/bookmark fetching with feature detection

The original snapshot fetching relied on a complex state-dependent
`getsnaps()` subroutine with a separate `getsnapsfallback()` for older
ZFS versions. The first refactor attempt in #818 simplified this but
introduced performance regressions by using `zfs get all`, which was
inefficient for large datasets.

This commit avoids that overhead by integrating proactive `zfs get`
feature detection through a new `check_zfs_get_features()` subroutine
that determines the command's capabilities by testing for `-t` (type
filter) support and the availability of the `createtxg` property.
Results are cached per host to avoid redundant checks.
`check_zfs_get_features()` came from the #931, which this change
supersedes.

The `getsnaps()` and `getbookmarks()` subroutines now use this
information to build optimized `zfs get` commands that query only
necessary properties. As before in #818, the parsing logic is refactored
to populate property hashes for each item, eliminating the old
multi-loop state-dependent approach and the need for mostly duplicated
fallback logic.

This resolves both the original complexity and the performance issues
from the first attempted fix. Now there is a foundation for fixing the
snapshot ordering bug reported in #815.

### feat(syncoid): Sort snapshots reliably using the `createtxg` property

System clock adjustments from manual changes or NTP synchronization can 
cause ZFS snapshot creation timestamps to be non-monotonic. This can 
cause `syncoid` to select the wrong "oldest" snapshot for initial 
replication or the wrong "newest" snapshot with `--no-sync-snap`, 
potentially losing data from the source to the target.

This change adds the `sortsnapshots()` helper that prefers to compare 
the `createtxg` (creation transaction group) property over the 
`creation` property when available. The `createtxg` property is 
guaranteed to be strictly sequential within a ZFS pool, unlike the 
`creation` property, which depends on the system clock's accuracy.

Unlike the first iteration of `sortsnapshots()` in #818, the subroutine 
takes a specific snapshot sub-hash ('source' or 'target') as input 
rather than both, ensuring createtxg comparisons occur within the same 
zpool context. The first iteration that took the entire snapshots hash 
had no mechanism to sort target snapshots, which could have caused 
issues in usages that expected target snapshots to be sorted.

Most snapshot sorting call sites now use the new `sortsnapshots()`
subroutine. Two more usages involving bookmarks are updated in a
different commit for independent testing of a bookmarks-related
refactoring.

Fixes: #815

### fix(syncoid): Harden bookmark replication against timestamp non-monotony

* Replaced direct sorting on the `creation` property with calls to the
  `sortsnapshots()` helper subroutine. As with other usages, this
  ensures that when `syncoid` searches for the next snapshot to
  replicate from a bookmark, it preferentially uses the monotonic
  `createtxg` for sorting.
* Refactored the variables holding bookmark details from separate
  scalars (`$bookmark`, `$bookmarkcreation`) into a single hash
  (`%bookmark`). This allows for cleaner handling of all
  relevant bookmark properties (`name`, `creation`, `createtxg`).
* Fixed a code comment that incorrectly described the snapshot search
  order. The search for a matching target snapshot now correctly states
  it proceeds from newest-to-oldest to find the most recent common
  ancestor.

### test(syncoid): Add test to verify out-of-order snapshot sync

This commit adds a regression test for the out-of-order snapshot
replication issue.

The new test case manipulates the system clock with `setdate` to create
snapshots with non-monotonic `creation` timestamps but a correct,
sequential `createtxg`. It then runs `syncoid` and verifies that all
snapshots were replicated, which is only possible if they are ordered
correctly by `createtxg`.

See #815 for the original test.

### fix(tests/common/lib.sh): Support set -e in test scripts

The `systemctl is-active virtualbox-guest-utils.service` command returns
a non-zero exit status when the service is inactive, causing early exit
in tests that use `set -e`.

This change suppresses that error with `|| true` to prevent test failure
when the service check returns non-zero.

Fixes this test:

```
root@demo:~/sanoid/tests/syncoid# cat /tmp/syncoid_test_run_011_sync_out-of-order_snapshots.log
+ set -e
+ . ../../common/lib.sh
+++ uname
++ unamestr=Linux
+ POOL_IMAGE=/tmp/jimsalterjrs_sanoid_815.img
+ POOL_SIZE=64M
+ POOL_NAME=jimsalterjrs_sanoid_815
+ truncate -s 64M /tmp/jimsalterjrs_sanoid_815.img
+ zpool create -m none -f jimsalterjrs_sanoid_815 /tmp/jimsalterjrs_sanoid_815.img
+ trap cleanUp EXIT
+ zfs create jimsalterjrs_sanoid_815/before
+ zfs snapshot jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset
+ disableTimeSync
+ which timedatectl
+ '[' 0 -eq 0 ']'
+ timedatectl set-ntp 0
+ which systemctl
+ '[' 0 -eq 0 ']'
+ systemctl is-active virtualbox-guest-utils.service
inactive
+ cleanUp
+ zpool export jimsalterjrs_sanoid_815
+ rm -f /tmp/jimsalterjrs_sanoid_815.img
```

## Related Issues

This pull request redoes #818 to fix #815 by integrating #931 and fixing one additional issue that went unnoticed in those previous pull requests:

1. `sortsnapshots()` was not able to sort target snapshots but can now do so.

## How Has This Been Tested?

All existing `syncoid` tests pass, plus the new regression test for out-of-order snapshots:

Before:

```shell
root@demo:~/sanoid/tests/syncoid# git checkout origin/fix/815 /root/sanoid/tests/common/lib.sh
Updated 1 path from 021cbc7
root@demo:~/sanoid/tests/syncoid# ./run-tests.sh
Running test 001_bookmark_replication_intermediate ... [PASS]
Running test 002_bookmark_replication_no_intermediate ... [PASS]
Running test 003_force_delete ... [PASS]
Running test 004_bookmark_replication_edge_case ... [PASS]
Running test 005_reset_resume_state ... mbuffer: error: outputThread: error writing to <stdout> at offset 0x40000: Broken pipe
mbuffer: warning: error during output to <stdout>: Broken pipe
[PASS]
Running test 006_reset_resume_state2 ... [PASS]
Running test 007_preserve_recordsize ... [PASS]
Running test 008_force_delete_snapshot ... [PASS]
Running test 009_preserve_properties ... [PASS]
Running test 010_filter_snaps ... [PASS]
Running test 011_sync_out-of-order_snapshots ... [FAILED] (see /tmp/syncoid_test_run_011_sync_out-of-order_snapshots.log)
Running test 012_receive_resume_token ... [PASS]
root@demo:~/sanoid/tests/syncoid# cat /tmp/syncoid_test_run_011_sync_out-of-order_snapshots.log
+ set -e
+ . ../../common/lib.sh
+++ uname
++ unamestr=Linux
+ POOL_IMAGE=/tmp/jimsalterjrs_sanoid_815.img
+ POOL_SIZE=64M
+ POOL_NAME=jimsalterjrs_sanoid_815
+ truncate -s 64M /tmp/jimsalterjrs_sanoid_815.img
+ zpool create -m none -f jimsalterjrs_sanoid_815 /tmp/jimsalterjrs_sanoid_815.img
+ trap cleanUp EXIT
+ zfs create jimsalterjrs_sanoid_815/before
+ zfs snapshot jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset
+ disableTimeSync
+ which timedatectl
+ '[' 0 -eq 0 ']'
+ timedatectl set-ntp 0
+ which systemctl
+ '[' 0 -eq 0 ']'
+ systemctl is-active virtualbox-guest-utils.service
inactive
+ true
+ setdate 1155533696
+ TIMESTAMP=1155533696
+ '[' Linux == FreeBSD ']'
+ date --utc --set @1155533696
Mon Aug 14 05:34:56 UTC 2006
+ zfs snapshot jimsalterjrs_sanoid_815/before@oldest-snapshot
+ zfs snapshot jimsalterjrs_sanoid_815/before@another-snapshot-does-not-matter
+ ../../../syncoid --sendoptions=Lec jimsalterjrs_sanoid_815/before jimsalterjrs_sanoid_815/after
INFO: Sending oldest full snapshot jimsalterjrs_sanoid_815/before@oldest-snapshot to new target filesystem jimsalterjrs_sanoid_815/after (~ 12 KB):
INFO: Sending incremental jimsalterjrs_sanoid_815/before@oldest-snapshot ... syncoid_demo_2006-08-14:05:34:56-GMT00:00 to jimsalterjrs_sanoid_815/after (~ 4 KB):
+ saveSnapshotList jimsalterjrs_sanoid_815 snapshot-list.txt
+ POOL_NAME=jimsalterjrs_sanoid_815
+ RESULT=snapshot-list.txt
+ zfs list -t snapshot -o name -Hr jimsalterjrs_sanoid_815
+ sort
+ '[' Linux == FreeBSD ']'
+ sed -i 's/\(autosnap_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:\)[0-9][0-9]/\100/g' snapshot-list.txt
+ grep jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset snapshot-list.txt
jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset
+ grep jimsalterjrs_sanoid_815/after@this-snapshot-should-make-it-into-the-after-dataset snapshot-list.txt
+ exit 1
+ cleanUp
+ zpool export jimsalterjrs_sanoid_815
+ rm -f /tmp/jimsalterjrs_sanoid_815.img
```

After:

```shell
root@demo:~/sanoid/tests/syncoid# ./run-tests.sh
Running test 001_bookmark_replication_intermediate ... [PASS]
Running test 002_bookmark_replication_no_intermediate ... [PASS]
Running test 003_force_delete ... [PASS]
Running test 004_bookmark_replication_edge_case ... [PASS]
Running test 005_reset_resume_state ... mbuffer: error: outputThread: error writing to <stdout> at offset 0x20000: Broken pipe
mbuffer: warning: error during output to <stdout>: Broken pipe
[PASS]
Running test 006_reset_resume_state2 ... [PASS]
Running test 007_preserve_recordsize ... [PASS]
Running test 008_force_delete_snapshot ... [PASS]
Running test 009_preserve_properties ... [PASS]
Running test 010_filter_snaps ... [PASS]
Running test 011_sync_out-of-order_snapshots ... [PASS]
Running test 012_receive_resume_token ... [PASS]
root@demo:~/sanoid/tests/syncoid# cat /tmp/syncoid_test_run_011_sync_out-of-order_snapshots.log
+ set -e
+ . ../../common/lib.sh
+++ uname
++ unamestr=Linux
+ POOL_IMAGE=/tmp/jimsalterjrs_sanoid_815.img
+ POOL_SIZE=64M
+ POOL_NAME=jimsalterjrs_sanoid_815
+ truncate -s 64M /tmp/jimsalterjrs_sanoid_815.img
+ zpool create -m none -f jimsalterjrs_sanoid_815 /tmp/jimsalterjrs_sanoid_815.img
+ trap cleanUp EXIT
+ zfs create jimsalterjrs_sanoid_815/before
+ zfs snapshot jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset
+ disableTimeSync
+ which timedatectl
+ '[' 0 -eq 0 ']'
+ timedatectl set-ntp 0
+ which systemctl
+ '[' 0 -eq 0 ']'
+ systemctl is-active virtualbox-guest-utils.service
inactive
+ true
+ setdate 1155533696
+ TIMESTAMP=1155533696
+ '[' Linux == FreeBSD ']'
+ date --utc --set @1155533696
Mon Aug 14 05:34:56 UTC 2006
+ zfs snapshot jimsalterjrs_sanoid_815/before@oldest-snapshot
+ zfs snapshot jimsalterjrs_sanoid_815/before@another-snapshot-does-not-matter
+ ../../../syncoid --sendoptions=Lec jimsalterjrs_sanoid_815/before jimsalterjrs_sanoid_815/after
INFO: Sending oldest full snapshot jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset to new target filesystem jimsalterjrs_sanoid_815/after (~ 12 KB):
INFO: Sending incremental jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset ... syncoid_demo_2006-08-14:05:34:56-GMT00:00 to jimsalterjrs_sanoid_815/after (~ 4 KB):
+ saveSnapshotList jimsalterjrs_sanoid_815 snapshot-list.txt
+ POOL_NAME=jimsalterjrs_sanoid_815
+ RESULT=snapshot-list.txt
+ zfs list -t snapshot -o name -Hr jimsalterjrs_sanoid_815
+ sort
+ '[' Linux == FreeBSD ']'
+ sed -i 's/\(autosnap_[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]_[0-9][0-9]:[0-9][0-9]:\)[0-9][0-9]/\100/g' snapshot-list.txt
+ grep jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset snapshot-list.txt
jimsalterjrs_sanoid_815/before@this-snapshot-should-make-it-into-the-after-dataset
+ grep jimsalterjrs_sanoid_815/after@this-snapshot-should-make-it-into-the-after-dataset snapshot-list.txt
jimsalterjrs_sanoid_815/after@this-snapshot-should-make-it-into-the-after-dataset
+ grep jimsalterjrs_sanoid_815/before@oldest-snapshot snapshot-list.txt
jimsalterjrs_sanoid_815/before@oldest-snapshot
+ grep jimsalterjrs_sanoid_815/after@oldest-snapshot snapshot-list.txt
jimsalterjrs_sanoid_815/after@oldest-snapshot
+ grep jimsalterjrs_sanoid_815/before@another-snapshot-does-not-matter snapshot-list.txt
jimsalterjrs_sanoid_815/before@another-snapshot-does-not-matter
+ grep jimsalterjrs_sanoid_815/after@another-snapshot-does-not-matter snapshot-list.txt
jimsalterjrs_sanoid_815/after@another-snapshot-does-not-matter
+ exit 0
+ cleanUp
+ zpool export jimsalterjrs_sanoid_815
+ rm -f /tmp/jimsalterjrs_sanoid_815.img
```

I manually tested the [`zfs get`](https://openzfs.github.io/openzfs-docs/man/master/8/zfs-get.8.html) feature detection feature on an old ZFS pool version 28 / ZFS file system version 5 setup in FreeBSD 8.3:

```
[root@FREEBSD ~/sanoid]# sysctl vfs.zfs.version
vfs.zfs.version.zpl: 5
vfs.zfs.version.spa: 28
vfs.zfs.version.acl: 1
```

On this FreeBSD 8.3 machine, I created some dummy snapshots:

```
[root@FREEBSD ~/sanoid]# zfs list -rtall
NAME                                                               USED  AVAIL  REFER  MOUNTPOINT
rpool                                                              224M   760M    32K  /rpool
rpool/before                                                       224M   760M  32.1M  /rpool/before
rpool/before@this-snapshot-should-make-it-into-the-after-dataset   128M      -   128M  -
rpool/before@a-snapshot                                           64.1M      -  64.1M  -
rpool/before@another-snapshot                                         0      -  32.1M  -
```

And `syncoid` was able to transfer them out:

```
root@workstation [~]# ./syncoid --debug root@192.168.122.70:rpool/before syncoid-test-11/after
DEBUG: SSHCMD: ssh     
Warning: Permanently added '192.168.122.70' (RSA) to the list of known hosts.
(root@192.168.122.70) Password:
DEBUG: checking availability of lzop on source...
DEBUG: checking availability of lzop on target...
DEBUG: checking availability of lzop on local machine...
WARNING: lzop not available on source ssh:-S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70- sync will continue without compression.
DEBUG: checking availability of mbuffer on source...
WARNING: mbuffer not available on source ssh:-S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70 - sync will continue without source buffering.
DEBUG: checking availability of mbuffer on target...
DEBUG: checking availability of pv on local machine...
DEBUG: checking availability of zfs resume feature on source...
DEBUG: checking availability of zfs resume feature on target...
WARNING: ZFS resume feature not available on source machine - sync will continue without resume support.
DEBUG: syncing source rpool/before to target syncoid-test-11/after.
DEBUG: getting current value of syncoid:sync on rpool/before...
DEBUG: ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70  zfs get -H syncoid:sync ''"'"'rpool/before'"'"''
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
DEBUG: checking to see if target filesystem exists using "  zfs get -H name 'syncoid-test-11/after' 2>&1 |"...
DEBUG: Checking `zfs get` features on host "root@192.168.122.70"...
DEBUG: Host "root@192.168.122.70" has `zfs get -t`?: 0
DEBUG: Host "root@192.168.122.70" ZFS properties: guid creation createtxg
DEBUG: getting list of snapshots on rpool/before using ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70  zfs get -Hpd 1  guid,creation,createtxg,type ''"'"'rpool/before'"'"'' |...
DEBUG: creating sync snapshot using "ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70  zfs snapshot ''"'"'rpool/before'"'"''@syncoid_workstation.wizard2.net_2025-06-11:23:49:29-GMT-05:00
"...
DEBUG: target syncoid-test-11/after does not exist.  Finding oldest available snapshot on source rpool/before ...
DEBUG: getting estimated transfer size from source -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70 using "ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70  zfs send  -nvP ''"'"'rpool/before@this-snapshot-should-make-it-into-the-after-dataset'"'"'' 2>&1 |"...
DEBUG: sendsize = 134470344
INFO: Sending oldest full snapshot root@192.168.122.70:rpool/before@this-snapshot-should-make-it-into-the-after-dataset to new target filesystem syncoid-test-11/after (~ 128.2 MB):
DEBUG: sync size: ~128.2 MB
DEBUG: ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70 ' zfs send  '"'"'rpool/before'"'"'@'"'"'this-snapshot-should-make-it-into-the-after-dataset'"'"'' | mbuffer  -q -s 128k -m 16M | pv -p -t -e -r -b -s 134470344 |  zfs receive  -F 'syncoid-test-11/after' 2>&1
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
 128MiB 0:00:02 [44.0MiB/s] [============================================================================================================================================================================================================================================>] 100%            
DEBUG: getting estimated transfer size from source -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70 using "ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70  zfs send  -nvP -I ''"'"'rpool/before@this-snapshot-should-make-it-into-the-after-dataset'"'"'' ''"'"'rpool/before@syncoid_workstation.wizard2.net_2025-06-11:23:49:29-GMT-05:00'"'"'' 2>&1 |"...
DEBUG: sendsize = 100858256
INFO: Sending incremental root@192.168.122.70:rpool/before@this-snapshot-should-make-it-into-the-after-dataset ... syncoid_workstation.wizard2.net_2025-06-11:23:49:29-GMT-05:00 to syncoid-test-11/after (~ 96.2 MB):
DEBUG: sync size: ~96.2 MB
DEBUG: ssh      -S /tmp/syncoid-root19216812270-1749703767-3334611-8120 root@192.168.122.70 ' zfs send  -I '"'"'rpool/before'"'"'@'"'"'this-snapshot-should-make-it-into-the-after-dataset'"'"' '"'"'rpool/before'"'"'@'"'"'syncoid_workstation.wizard2.net_2025-06-11:23:49:29-GMT-05:00'"'"'' | mbuffer  -q -s 128k -m 16M | pv -p -t -e -r -b -s 100858256 |  zfs receive  -F 'syncoid-test-11/after' 2>&1
DEBUG: checking to see if syncoid-test-11/after on  is already in zfs receive using  ps -Ao args= ...
96.2MiB 0:00:02 [40.7MiB/s] [============================================================================================================================================================================================================================================>] 100%            
root@workstation [~]# zfs list -rtall syncoid-test-11
NAME                                                                                  USED  AVAIL  REFER  MOUNTPOINT
syncoid-test-11                                                                       224M   608M    25K  /syncoid-test-11
syncoid-test-11/after                                                                 224M   608M  32.0M  /syncoid-test-11/after
syncoid-test-11/after@this-snapshot-should-make-it-into-the-after-dataset             128M      -   128M  -
syncoid-test-11/after@a-snapshot                                                     64.1M      -  64.1M  -
syncoid-test-11/after@another-snapshot                                                  0B      -  32.0M  -
syncoid-test-11/after@syncoid_workstation.wizard2.net_2025-06-11:23:49:29-GMT-05:00     0B      -  32.0M  -
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)