### PR TITLE
get snpshots from configured list of datasets only

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -883,7 +883,8 @@ sub getsnaps {
 					print "INFO: cache expired - updating from zfs list.\n";
 				}
 			}
-			open FH, "$zfs get -Hrpt snapshot creation |";
+			# just get snapshots from configured datasets to not spin up the disks
+			open FH, "$zfs get -Hrpt snapshot creation ".join(" ",keys %$config)." |";
 			@rawsnaps = <FH>;
 			close FH;
 


### PR DESCRIPTION

query the existing snapshots only from the configured datasets to avoid spinning up disks that are not in the config file