### PR TITLE
fixed file handle conflict

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -1084,10 +1084,8 @@ sub init {
 			@datasets = getchilddatasets($config{$section}{'path'});
 			DATASETS: foreach my $dataset(@datasets) {
 				if (! @cachedatasets) {
-					push (@updatedatasets, $dataset);
+					push (@updatedatasets, "$dataset\n");
 				}
-
-				chomp $dataset;
 
 				if ($zfsRecursive) {
 					# don't try to take the snapshot ourself, recursive zfs snapshot will take care of that
@@ -1691,7 +1689,7 @@ sub getchilddatasets {
 	my $getchildrencmd = "$mysudocmd $zfs list -o name -t filesystem,volume -Hr $fs |";
 	 if ($args{'debug'}) { print "DEBUG: getting list of child datasets on $fs using $getchildrencmd...\n"; }
 	open FH, $getchildrencmd;
-	my @children = <FH>;
+	chomp( my @children = <FH> );
 	close FH;
 
 	# parent dataset is the first element
@@ -1781,25 +1779,26 @@ sub addcachedsnapshots {
 
 	copy($cache, "$cache.tmp") or die "Could not copy to $cache.tmp!\n";
 
-	open FH, ">> $cache.tmp" or die "Could not write to $cache.tmp!\n";
+	open my $fh, ">> $cache.tmp" or die "Could not write to $cache.tmp!\n";
 	while((my $snap, my $details) = each(%taken)) {
 		my @parts = split("@", $snap, 2);
 
 		my $suffix = $parts[1] . "\tcreation\t" . $details->{time} . "\t-";
 		my $dataset = $parts[0];
 
-		print FH "${dataset}\@${suffix}\n";
+		print $fh "${dataset}\@${suffix}\n";
 
 		if ($details->{recursive}) {
 			my @datasets = getchilddatasets($dataset);
 
 			foreach my $dataset(@datasets) {
-				print FH "${dataset}\@${suffix}\n";
+				print "${dataset}\@${suffix}\n";
+				print $fh "${dataset}\@${suffix}\n";
 			}
 		}
 	}
 
-	close FH;
+	close $fh;
 
 	# preserve mtime of cache for expire check
 	my ($dev, $ino, $mode, $nlink, $uid, $gid, $rdev, $size, $atime, $mtime, $ctime, $blksize, $blocks) = stat($cache);


### PR DESCRIPTION
this fixes a regression introduced with #1005 which leads to multiple unneeded snapshots with specific configurations which include "recursive = zfs".

In Perl using the old style of opening a file with a bareword as filehandle

`open(FH, "<", "input.txt")`

one has to consider that FH is a global variable.

In this edge case a subroutine was called (if the cache was expired) which also does open the same bareword filehandle and because it's global once the subroutine was finished the filehandle  was closed and the caller couldn't write it anymore. Therefore the cache was missing taken snapshots and on the next sanoid run they were taken again.

Fixes #1014 #1020
