### PR TITLE
feat: warn if template can't be found

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -1020,6 +1020,12 @@ sub init {
 				$rawtemplate =~ s/\s+$//g;
 
 				my $template = 'template_'.$rawtemplate;
+
+                # Check if template exists
+                if (!exists $ini{$template}) {
+                    die "FATAL ERROR: Template '$rawtemplate' referenced in section [$section] does not exist in $conf_file.\n";
+                }
+
 				foreach my $key (keys %{$ini{$template}}) {
 					if ($key =~ /template|recursive/) {
 						warn "ignored key '$key' from '$rawtemplate' template.\n";

--- a/sanoid
+++ b/sanoid
@@ -1021,9 +1021,9 @@ sub init {
 
 				my $template = 'template_'.$rawtemplate;
 
-                # Check if template exists
+                # Check if template exists - warn otherwise
                 if (!exists $ini{$template}) {
-                    die "FATAL ERROR: Template '$rawtemplate' referenced in section [$section] does not exist in $conf_file.\n";
+                    warn "WARN: Template '$rawtemplate' referenced in section [$section] does not exist in $conf_file.\n";
                 }
 
 				foreach my $key (keys %{$ini{$template}}) {


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

Fixes #1038

Hi,

This 3 line changes adds an important safety net: if the template cannot be found we crash instead of continuing as usual. In my case I had been trying to use template `"docker"` instead of `docker` for a while and never figured it out until today.

I believe if a template is declared and never used we should also crash.

I can't perl so I asked an LLM and then tested on my end.



edit:

I'm adding a second commit to crash if there are unused templates.