### PR TITLE
Change syncoid snapshots date and time divider from ":" to "_"

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -2197,7 +2197,7 @@ sub getdate {
 	$date{'mday'} = sprintf ("%02u", $mday);
 	$date{'mon'} = sprintf ("%02u", ($mon + 1));
 	$date{'tzoffset'} = sprintf ("GMT%s%02d:%02u", $sign, $hours, $minutes);
-	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}:$date{'hour'}:$date{'min'}:$date{'sec'}-$date{'tzoffset'}";
+	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}_$date{'hour'}:$date{'min'}:$date{'sec'}-$date{'tzoffset'}";
 	return %date;
 }
 


### PR DESCRIPTION
Right now the sanoid and syncoid snapshots are parsing the date and time differently:
Sanoid appends e.g. `_2023-07-25_20:00:14-GMT03:00` while
Syncoid appends `_2023-07-25:20:00:14-GMT03:00`.

Basically, Syncoid uses a ":" to divide the date and the time, while Sanoid uses a "_" to do that.

If this isnt intended behavious, this pull request would just replace the `:` with a `_` in the syncoid data-parsing.

As the `get_date()` function is only used at [one place in Syncoid](https://github.com/jimsalterjrs/sanoid/blob/dbcaeef1ac55bd3dd929b86a8f6082fef16f02b1/syncoid#L1750) (setting the name for a new snapshot), this change wouldn't break anything as far as I can tell