### PR TITLE
Change date stamp format to use underscore

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -2197,7 +2197,7 @@ sub getdate {
 	$date{'mday'} = sprintf ("%02u", $mday);
 	$date{'mon'} = sprintf ("%02u", ($mon + 1));
 	$date{'tzoffset'} = sprintf ("GMT%s%02d:%02u", $sign, $hours, $minutes);
-	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}:$date{'hour'}:$date{'min'}:$date{'sec'}-$date{'tzoffset'}";
+	$date{'stamp'} = "$date{'year'}-$date{'mon'}-$date{'mday'}_$date{'hour'}:$date{'min'}:$date{'sec'}-$date{'tzoffset'}";
 	return %date;
 }
 


### PR DESCRIPTION
This will change date stamp format to use underscore between date and hour:

`system_cache_ssd/appdata@syncoid_MyServer_2025-11-14:20:00:21-GMT02:00`

to : 

`system_cache_ssd/appdata@syncoid_MyServer_2025-11-14_20:00:21-GMT02:00`
