### PR TITLE
Fix iszfsbusy to not match pool prefix

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1402,7 +1402,7 @@ sub iszfsbusy {
 	close PL;
 
 	foreach my $process (@processes) {
-		if ($process =~ /zfs *(receive|recv)[^\/]*\Q$fs\E\Z/) {
+		if ($process =~ /zfs *(receive|recv)[^\/]*\s\Q$fs\E\Z/) {
 			# there's already a zfs receive process for our target filesystem - return true
 			writelog('DEBUG', "process $process matches target $fs!");
 			return 1;


### PR DESCRIPTION
This fixes an issue where if you try to simultaneously sync to two filesystems which have a matching prefix, syncoid thinks the filesystem is already in a `zfs recv`.

The problem is that the `[^\/]*` regex in `iszfsbusy` matches prefixes of pool names. This adds a `\s` before `\Q$fs\E` to make sure that there is some separator before the filesystem, preventing the `[^\/]*` part from eating into the pool name.

For testing I created two pools called `backuppool` and `pool`, started a sync to `backuppool/files`, and then tried to sync to `pool/files` and got `Cannot sync now: pool/files is already target of a zfs receive process`. With this fix, I was able to run both syncs at the same time.

Something to consider: `[^\/]*` is a crude way of matching flags passed to `zfs recv`. Now that we match a space separator before the filesystem, perhaps `.*` makes more sense. Let me know if I should make that change as well.