### PR TITLE
Change shebang to use '#!/usr/bin/env NAME' for portability

### DIFF
--- a/findoid
+++ b/findoid
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # this software is licensed for use under the Free Software Foundation's GPL v3.0 license, as retrieved
 # from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this

--- a/sanoid
+++ b/sanoid
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # this software is licensed for use under the Free Software Foundation's GPL v3.0 license, as retrieved
 # from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this

--- a/sleepymutex
+++ b/sleepymutex
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # this is just a cheap way to trigger mutex-based checks for process activity.
 #

--- a/syncoid
+++ b/syncoid
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # this software is licensed for use under the Free Software Foundation's GPL v3.0 license, as retrieved
 # from http://www.gnu.org/licenses/gpl-3.0.html on 2014-11-17.  A copy should also be available in this


### PR DESCRIPTION
Use the first (perl|bash) found in the user's path, rather than hardcoding
/usr/bin/perl and /bin/bash. This allows for the use of a version of (perl|bash)
of the user's choice, rather than requiring the use of the 'system' installed
version. Multiple installed versions are common when using `homebrew` to install
newer versions of (perl|bash) on MacOS or Linux. This is also needed when using
a version manager such as `asdf` or `mise` to manage multiple language runtime
versions.