### PR TITLE
don't print cache updates on stdout

### DIFF
--- a/sanoid
+++ b/sanoid
@@ -1792,7 +1792,6 @@ sub addcachedsnapshots {
 			my @datasets = getchilddatasets($dataset);
 
 			foreach my $dataset(@datasets) {
-				print "${dataset}\@${suffix}\n";
 				print $fh "${dataset}\@${suffix}\n";
 			}
 		}


### PR DESCRIPTION
Commit 393a4672e5695af5a5a8c82faed455e5689e0c69 added a line which printed cache updates to stdout.
This causes cron to send the output of the command as email.
I believe this was a mistake. If not, then the line should be executed only if the `--verbose` flag is passed.

@phreaker0