### PR TITLE
perf(syncoid): Escape SSH empty-string args in `check_zfs_get_features()` to avoid checking all datasets

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1442,7 +1442,12 @@ sub check_zfs_get_features {
 		supported_properties => ['guid', 'creation']
 	};
 
-	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot '' ''";
+	my $empty_ds = escapeshellparam('');
+	if ($rhost ne '') {
+		$empty_ds = escapeshellparam($empty_ds);
+	}
+
+	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot $empty_ds $empty_ds";
 	open my $fh_t, "$check_t_option_cmd 2>&1 |";
 	my $output_t = <$fh_t>;
 	close $fh_t;
@@ -1455,7 +1460,7 @@ sub check_zfs_get_features {
 
 	my @properties_to_check = ('createtxg');
 	foreach my $prop (@properties_to_check) {
-		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop ''";
+		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop $empty_ds";
 		open my $fh_p, "$check_prop_cmd 2>&1 |";
 		my $output_p = <$fh_p>;
 		close $fh_p;


### PR DESCRIPTION
## Motivation and Context

This pull request fixes https://github.com/jimsalterjrs/sanoid/issues/1085, a bug introduced in https://github.com/jimsalterjrs/sanoid/pull/1007 where the `check_zfs_get_features()` subroutine's `zfs get` probe commands do not properly escape their empty-string dataset arguments for SSH-based replication.  The empty strings, intended to trigger a fast error for feature detection, evaporate during SSH's argument concatenation, causing the remote side to run `zfs get` against every dataset and snapshot on the system.

@phreaker0 reported the issue in https://github.com/jimsalterjrs/sanoid/pull/1007#issuecomment-4109152658.

## Description

### fix(syncoid): Escape empty-string args in `check_zfs_get_features()` for SSH

The `zfs get` probe commands in `check_zfs_get_features()` use an empty
string as the dataset argument to trigger a fast error without querying
real data.  For local replication, the bare `''` works as intended, but
for SSH-based replication, the local shell consumes the quotes before
SSH sees them.  SSH then concatenates an empty argument into the remote
command, effectively dropping it, so the remote side runs `zfs get`
with no dataset argument, fetching the property from every dataset and
snapshot on the system.

Apply the same `escapeshellparam()` double-escaping pattern used by
`getsnaps()` and other subroutines to preserve the empty-string argument
through the SSH shell layer.

Fixes: https://github.com/jimsalterjrs/sanoid/issues/1085

## Related Issues

This is a follow-up fix to https://github.com/jimsalterjrs/sanoid/pull/1007, which introduced `check_zfs_get_features()` as part of the fix for https://github.com/jimsalterjrs/sanoid/issues/815.

As a future improvement, a dedicated `escapeshellparam_for_host()` helper could internalize the "escape once locally, twice for SSH" pattern to prevent this class of bug from recurring.  It looks like the double-escape pattern is currently repeated across at least a dozen call sites in `syncoid`, and it is easy to miss (as happened in https://github.com/jimsalterjrs/sanoid/pull/1007).

## How Has This Been Tested?

### Correctness

Using a test harness that extracts `check_zfs_get_features()` and its dependencies from two Git refs and compares results:

```
deltik@workstation [~/Documents/Development/IdeaProjects/sanoid]$ ./test_check_zfs_get_features.pl HEAD~1 HEAD 'ssh root@box1.deltik.net'
Before (HEAD~1): supports_type_filter=1 supported_properties=[guid, creation, createtxg]
After  (HEAD):  supports_type_filter=1 supported_properties=[guid, creation, createtxg]
PASS: results match
```

#### Correctness Test Harness Source Code

<details>
<summary><code>test_check_zfs_get_features.pl</code></summary>

```perl
#!/usr/bin/perl
# Correctness test for check_zfs_get_features() across two Git refs
# Usage: ./test_check_zfs_get_features.pl <ref-before> <ref-after> <rhost>
# Exits 0 if both refs produce the same feature detection results.
use strict;
use warnings;

my $ref_before = $ARGV[0] // die "Usage: $0 <ref-before> <ref-after> <rhost>\n";
my $ref_after  = $ARGV[1] // die "Usage: $0 <ref-before> <ref-after> <rhost>\n";
my $rhost      = $ARGV[2] // '';

sub extract_and_run {
	my ($ref, $rhost) = @_;

	my $source = `git show $ref:syncoid` or die "Failed to read syncoid at $ref\n";

	my %subs;
	while ($source =~ /^(sub (escapeshellparam|check_zfs_get_features|writelog) \{.*?^\})/gms) {
		$subs{$2} = $1;
	}

	die "Could not extract escapeshellparam from $ref\n"       unless $subs{escapeshellparam};
	die "Could not extract check_zfs_get_features from $ref\n" unless $subs{check_zfs_get_features};

	my $pkg = "Ref_" . ($ref =~ s/[^a-zA-Z0-9]/_/gr);
	my $code = "package $pkg; use strict; use warnings;\n";
	$code .= "our \%host_zfs_get_features;\n";
	$code .= "sub writelog { }\n";
	$code .= "$subs{escapeshellparam}\n";
	$code .= "$subs{check_zfs_get_features}\n";
	$code .= "1;\n";

	eval $code;
	die "Eval failed for $ref: $@\n" if $@;

	my $fn = "${pkg}::check_zfs_get_features";
	no strict 'refs';
	return $fn->($rhost, '', 'zfs');
}

my $result_before = extract_and_run($ref_before, $rhost);
my $result_after  = extract_and_run($ref_after,  $rhost);

sub format_result {
	my ($result) = @_;
	my $props = join(', ', @{$result->{supported_properties}});
	return "supports_type_filter=$result->{supports_type_filter} supported_properties=[$props]";
}

my $str_before = format_result($result_before);
my $str_after  = format_result($result_after);

print "Before ($ref_before): $str_before\n";
print "After  ($ref_after):  $str_after\n";

if ($str_before eq $str_after) {
	print "PASS: results match\n";
	exit 0;
} else {
	print "FAIL: results differ\n";
	exit 1;
}
```

</details>

### Performance

Using a benchmark harness that extracts and runs `check_zfs_get_features()` from a given Git ref:

```
deltik@workstation [~/Documents/Development/IdeaProjects/sanoid]$ hyperfine --warmup=1 \
  './bench_check_zfs_get_features.pl HEAD~1 "ssh root@box1.deltik.net"' \
  './bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net"'
Benchmark 1: ./bench_check_zfs_get_features.pl HEAD~1 "ssh root@box1.deltik.net"
  Time (mean ± σ):      2.029 s ±  0.077 s    [User: 0.011 s, System: 0.013 s]
  Range (min … max):    1.913 s …  2.187 s    10 runs

Benchmark 2: ./bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net"
  Time (mean ± σ):     927.4 ms ±  75.1 ms    [User: 15.5 ms, System: 15.3 ms]
  Range (min … max):   878.7 ms … 1126.2 ms    10 runs

Summary
  ./bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net" ran
    2.19 ± 0.20 times faster than ./bench_check_zfs_get_features.pl HEAD~1 "ssh root@box1.deltik.net"
```

#### Performance Test Harness Source Code

<details>
<summary><code>bench_check_zfs_get_features.pl</code></summary>

```perl
#!/usr/bin/perl
# Benchmark harness for check_zfs_get_features() extracted from Git history
# Usage: ./bench_check_zfs_get_features.pl <git-ref> <rhost>
# Example: hyperfine './bench_check_zfs_get_features.pl HEAD~1 "ssh root@host"' \
#                     './bench_check_zfs_get_features.pl HEAD "ssh root@host"'
use strict;
use warnings;

my $ref   = $ARGV[0] // die "Usage: $0 <git-ref> <rhost>\n";
my $rhost = $ARGV[1] // '';

my $source = `git show $ref:syncoid` or die "Failed to read syncoid at $ref\n";

my %subs;
while ($source =~ /^(sub (escapeshellparam|check_zfs_get_features|writelog) \{.*?^\})/gms) {
	$subs{$2} = $1;
}

die "Could not extract escapeshellparam from $ref\n"          unless $subs{escapeshellparam};
die "Could not extract check_zfs_get_features from $ref\n"    unless $subs{check_zfs_get_features};

my $code = "use strict; use warnings;\n";
$code .= "our \%host_zfs_get_features;\n";
$code .= "sub writelog { }\n";
$code .= "$subs{escapeshellparam}\n";
$code .= "$subs{check_zfs_get_features}\n";
$code .= "1;\n";

eval $code;
die "Eval failed: $@\n" if $@;

check_zfs_get_features($rhost, '', 'zfs');
```

</details>

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)