### PR TITLE
syncoid: Simplify remote command dispatch with `rhostcmd()`

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1442,7 +1442,12 @@ sub check_zfs_get_features {
 		supported_properties => ['guid', 'creation']
 	};
 
-	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot '' ''";
+	my $empty_ds = escapeshellparam('');
+	if ($rhost ne '') {
+		$empty_ds = escapeshellparam($empty_ds);
+	}
+
+	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot $empty_ds $empty_ds";
 	open my $fh_t, "$check_t_option_cmd 2>&1 |";
 	my $output_t = <$fh_t>;
 	close $fh_t;
@@ -1455,7 +1460,7 @@ sub check_zfs_get_features {
 
 	my @properties_to_check = ('createtxg');
 	foreach my $prop (@properties_to_check) {
-		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop ''";
+		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop $empty_ds";
 		open my $fh_p, "$check_prop_cmd 2>&1 |";
 		my $output_p = <$fh_p>;
 		close $fh_p;

--- a/syncoid
+++ b/syncoid
@@ -324,13 +324,8 @@ sub getchilddatasets {
 	my $fsescaped = escapeshellparam($fs);
 
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
 
-	my $getchildrencmd = "$rhost $mysudocmd $zfscmd list -o name,origin -t filesystem,volume -Hr $fsescaped |";
+	my $getchildrencmd = rhostcmd($rhost, "$mysudocmd $zfscmd list -o name,origin -t filesystem,volume -Hr $fsescaped") . " |";
 	writelog('DEBUG', "getting list of child datasets on $fs using $getchildrencmd...");
 	if (! open FH, $getchildrencmd) {
 		die "ERROR: list command failed!\n";
@@ -629,21 +624,16 @@ sub syncdataset {
 				if ($args{'force-delete'} && index($targetfs, '/') != -1) {
 					writelog('INFO', "Removing $targetfs because no matching snapshots were found");
 
-					my $rcommand = '';
 					my $mysudocmd = '';
 					my $targetfsescaped = escapeshellparam($targetfs);
 
-					if ($targethost ne '') { $rcommand = "$sshcmd $targethost"; }
 					if (!$targetisroot) { $mysudocmd = $sudocmd; }
 
-					my $prunecmd = "$mysudocmd $zfscmd destroy -r $targetfsescaped; ";
-					if ($targethost ne '') {
-						$prunecmd = escapeshellparam($prunecmd);
-					}
+					my $cmd = rhostcmd($targethost, "$mysudocmd $zfscmd destroy -r $targetfsescaped; ");
 
-					my $ret = system("$rcommand $prunecmd");
+					my $ret = system($cmd);
 					if ($ret != 0) {
-						writelog('WARN', "$rcommand $prunecmd failed: $?");
+						writelog('WARN', "$cmd failed: $?");
 					} else {
 						# redo sync and skip snapshot creation (already taken)
 						return syncdataset($sourcehost, $sourcefs, $targethost, $targetfs, undef, 1);
@@ -780,21 +770,16 @@ sub syncdataset {
 						}
 
 						writelog('WARN', "removing existing destination: $existing");
-						my $rcommand = '';
 						my $mysudocmd = '';
 						my $existingescaped = escapeshellparam($existing);
 
-						if ($targethost ne '') { $rcommand = "$sshcmd $targethost"; }
 						if (!$targetisroot) { $mysudocmd = $sudocmd; }
 
-						my $prunecmd = "$mysudocmd $zfscmd destroy $existingescaped; ";
-						if ($targethost ne '') {
-							$prunecmd = escapeshellparam($prunecmd);
-						}
+						my $cmd = rhostcmd($targethost, "$mysudocmd $zfscmd destroy $existingescaped; ");
 
-						my $ret = system("$rcommand $prunecmd");
+						my $ret = system($cmd);
 						if ($ret != 0) {
-							warn "CRITICAL ERROR: $rcommand $prunecmd failed: $?";
+							warn "CRITICAL ERROR: $cmd failed: $?";
 							if ($exitcode < 2) { $exitcode = 2; }
 							return 0;
 						} else {
@@ -825,13 +810,8 @@ sub syncdataset {
 		my $hostid = hostname();
 		my $matchingsnapescaped = escapeshellparam($matchingsnap);
 		my $holdname = "syncoid\_$identifier$hostid";
-		if ($sourcehost ne '') {
-			$holdcmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd hold $holdname $sourcefsescaped\@$newsyncsnapescaped");
-			$holdreleasecmd = "$sshcmd $sourcehost " . escapeshellparam("$sourcesudocmd $zfscmd release $holdname $sourcefsescaped\@$matchingsnapescaped");
-		} else {
-			$holdcmd = "$sourcesudocmd $zfscmd hold $holdname $sourcefsescaped\@$newsyncsnapescaped";
-			$holdreleasecmd = "$sourcesudocmd $zfscmd release $holdname $sourcefsescaped\@$matchingsnapescaped";
-		}
+		$holdcmd = rhostcmd($sourcehost, "$sourcesudocmd $zfscmd hold $holdname $sourcefsescaped\@$newsyncsnapescaped");
+		$holdreleasecmd = rhostcmd($sourcehost, "$sourcesudocmd $zfscmd release $holdname $sourcefsescaped\@$matchingsnapescaped");
 		writelog('DEBUG', "Set new hold on source: $holdcmd");
 		system($holdcmd) == 0 or warn "WARNING: $holdcmd failed: $?";
 		# Do hold release only if matchingsnap exists
@@ -839,12 +819,8 @@ sub syncdataset {
 			writelog('DEBUG', "Release old hold on source: $holdreleasecmd");
 			system($holdreleasecmd) == 0 or warn "WARNING: $holdreleasecmd failed: $?";
 		}
-		if ($targethost ne '') {
-			$holdcmd = "$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd hold $holdname $targetfsescaped\@$newsyncsnapescaped");
-			$holdreleasecmd = "$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd release $holdname $targetfsescaped\@$matchingsnapescaped");
-		} else {
-			$holdcmd = "$targetsudocmd $zfscmd hold $holdname $targetfsescaped\@$newsyncsnapescaped";				$holdreleasecmd = "$targetsudocmd $zfscmd release $holdname $targetfsescaped\@$matchingsnapescaped";
-		}
+		$holdcmd = rhostcmd($targethost, "$targetsudocmd $zfscmd hold $holdname $targetfsescaped\@$newsyncsnapescaped");
+		$holdreleasecmd = rhostcmd($targethost, "$targetsudocmd $zfscmd release $holdname $targetfsescaped\@$matchingsnapescaped");
 		writelog('DEBUG', "Set new hold on target: $holdcmd");
 		system($holdcmd) == 0 or warn "WARNING: $holdcmd failed: $?";
 		# Do hold release only if matchingsnap exists
@@ -906,12 +882,7 @@ sub syncdataset {
 		while (@to_delete) {
 			# Create batch of snapshots to remove
 			my $snaps = join ',', splice(@to_delete, 0, 50);
-			my $command;
-			if ($targethost ne '') {
-				$command = "$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd destroy $targetfsescaped\@$snaps");
-			} else {
-				$command = "$targetsudocmd $zfscmd destroy $targetfsescaped\@$snaps";
-			}
+			my $command = rhostcmd($targethost, "$targetsudocmd $zfscmd destroy $targetfsescaped\@$snaps");
 			writelog('DEBUG', "$command");
 			my ($stdout, $stderr, $result) = capture { system $command; };
 			if ($result != 0 && !$quiet) {
@@ -1138,14 +1109,9 @@ sub createbookmark {
 	my ($sourcehost, $sourcefs, $snapname, $bookmark) = @_;
 
 	my $sourcefsescaped = escapeshellparam($sourcefs);
-	my $bookmarkescaped = escapeshellparam($bookmark);
-	my $snapnameescaped = escapeshellparam($snapname);
-	my $cmd = "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$snapname $sourcefsescaped\#$bookmark";
-	if ($sourcehost ne '') {
-		$cmd = "$sshcmd $sourcehost " . escapeshellparam($cmd);
-	}
+	my $cmd = rhostcmd($sourcehost, "$sourcesudocmd $zfscmd bookmark $sourcefsescaped\@$snapname $sourcefsescaped\#$bookmark");
 
-	writelog('DEBUG', "$cmd");
+	writelog('DEBUG', $cmd);
 	return system($cmd);
 } # end createbookmark()
 
@@ -1240,8 +1206,6 @@ sub checkcommands {
 	# source, target, and local hosts as appropriate.
 
 	my %avail;
-	my $sourcessh;
-	my $targetssh;
 
 	# if --nocommandchecks then assume everything's available and return
 	if ($args{'nocommandchecks'}) {
@@ -1256,18 +1220,17 @@ sub checkcommands {
 		return %avail;
 	}
 
-	if ($sourcehost ne '') { $sourcessh = "$sshcmd $sourcehost"; } else { $sourcessh = ''; }
-	if ($targethost ne '') { $targetssh = "$sshcmd $targethost"; } else { $targetssh = ''; }
-
 	# if raw compress command is null, we must have specified no compression. otherwise,
 	# make sure that compression is available everywhere we need it
 	if ($compressargs{'compress'} eq 'none') {
 		writelog('DEBUG', "compression forced off from command line arguments.");
 	} else {
 		writelog('DEBUG', "checking availability of $compressargs{'rawcmd'} on source...");
-		$avail{'sourcecompress'} = `$sourcessh $checkcmd $compressargs{'rawcmd'} 2>/dev/null`;
+		my $cmd = rhostcmd($sourcehost, "$checkcmd $compressargs{'rawcmd'}");
+		$avail{'sourcecompress'} = `$cmd 2>/dev/null`;
 		writelog('DEBUG', "checking availability of $compressargs{'rawcmd'} on target...");
-		$avail{'targetcompress'} = `$targetssh $checkcmd $compressargs{'rawcmd'} 2>/dev/null`;
+		$cmd = rhostcmd($targethost, "$checkcmd $compressargs{'rawcmd'}");
+		$avail{'targetcompress'} = `$cmd 2>/dev/null`;
 		writelog('DEBUG', "checking availability of $compressargs{'rawcmd'} on local machine...");
 		$avail{'localcompress'} = `$checkcmd $compressargs{'rawcmd'} 2>/dev/null`;
 	}
@@ -1323,14 +1286,16 @@ sub checkcommands {
 
 	if (length $args{'insecure-direct-connection'}) {
 		writelog('DEBUG', "checking availability of $socatcmd on source...");
-		my $socatAvailable = `$sourcessh $checkcmd $socatcmd 2>/dev/null`;
+		my $cmd = rhostcmd($sourcehost, "$checkcmd $socatcmd");
+		my $socatAvailable = `$cmd 2>/dev/null`;
 		if ($socatAvailable eq '') {
 			die "CRIT: $socatcmd is needed on source for insecure direct connection!\n";
 		}
 
 		if (!$directmbuffer) {
 			writelog('DEBUG', "checking availability of busybox (for nc) on target...");
-			my $busyboxAvailable = `$targetssh $checkcmd busybox 2>/dev/null`;
+			$cmd = rhostcmd($targethost, "$checkcmd busybox");
+			my $busyboxAvailable = `$cmd 2>/dev/null`;
 			if ($busyboxAvailable eq '') {
 				die "CRIT: busybox is needed on target for insecure direct connection!\n";
 			}
@@ -1338,7 +1303,8 @@ sub checkcommands {
 	}
 
 	writelog('DEBUG', "checking availability of $mbuffercmd on source...");
-	$avail{'sourcembuffer'} = `$sourcessh $checkcmd $mbuffercmd 2>/dev/null`;
+	my $cmd = rhostcmd($sourcehost, "$checkcmd $mbuffercmd");
+	$avail{'sourcembuffer'} = `$cmd 2>/dev/null`;
 	if ($avail{'sourcembuffer'} eq '') {
 		writelog('WARN', "$mbuffercmd not available on source $s - sync will continue without source buffering.");
 		$avail{'sourcembuffer'} = 0;
@@ -1347,7 +1313,8 @@ sub checkcommands {
 	}
 
 	writelog('DEBUG', "checking availability of $mbuffercmd on target...");
-	$avail{'targetmbuffer'} = `$targetssh $checkcmd $mbuffercmd 2>/dev/null`;
+	$cmd = rhostcmd($targethost, "$checkcmd $mbuffercmd");
+	$avail{'targetmbuffer'} = `$cmd 2>/dev/null`;
 	if ($avail{'targetmbuffer'} eq '') {
 		if ($directmbuffer) {
 			die "CRIT: $mbuffercmd is needed on target for insecure direct connection!\n";
@@ -1387,24 +1354,16 @@ sub checkcommands {
 		$srcpool = escapeshellparam($srcpool);
 		$dstpool = escapeshellparam($dstpool);
 
-		if ($sourcehost ne '') {
-			# double escaping needed
-			$srcpool = escapeshellparam($srcpool);
-		}
-
-		if ($targethost ne '') {
-			# double escaping needed
-			$dstpool = escapeshellparam($dstpool);
-		}
-
 		my $resumechkcmd = "$zpoolcmd get -o value -H feature\@extensible_dataset";
 
 		writelog('DEBUG', "checking availability of zfs resume feature on source...");
-		$avail{'sourceresume'} = system("$sourcessh $sourcesudocmd $resumechkcmd $srcpool 2>/dev/null | grep '\\(active\\|enabled\\)' >/dev/null 2>&1");
+		my $srcresumecmd = rhostcmd($sourcehost, "$sourcesudocmd $resumechkcmd $srcpool");
+		$avail{'sourceresume'} = system("$srcresumecmd 2>/dev/null | grep '\\(active\\|enabled\\)' >/dev/null 2>&1");
 		$avail{'sourceresume'} = $avail{'sourceresume'} == 0 ? 1 : 0;
 
 		writelog('DEBUG', "checking availability of zfs resume feature on target...");
-		$avail{'targetresume'} = system("$targetssh $targetsudocmd $resumechkcmd $dstpool 2>/dev/null | grep '\\(active\\|enabled\\)' >/dev/null 2>&1");
+		my $dstresumecmd = rhostcmd($targethost, "$targetsudocmd $resumechkcmd $dstpool");
+		$avail{'targetresume'} = system("$dstresumecmd 2>/dev/null | grep '\\(active\\|enabled\\)' >/dev/null 2>&1");
 		$avail{'targetresume'} = $avail{'targetresume'} == 0 ? 1 : 0;
 
 		if ($avail{'sourceresume'} == 0 || $avail{'targetresume'} == 0) {
@@ -1443,11 +1402,8 @@ sub check_zfs_get_features {
 	};
 
 	my $empty_ds = escapeshellparam('');
-	if ($rhost ne '') {
-		$empty_ds = escapeshellparam($empty_ds);
-	}
 
-	my $check_t_option_cmd = "$rhost $mysudocmd $zfscmd get -H -t snapshot $empty_ds $empty_ds";
+	my $check_t_option_cmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -H -t snapshot $empty_ds $empty_ds");
 	open my $fh_t, "$check_t_option_cmd 2>&1 |";
 	my $output_t = <$fh_t>;
 	close $fh_t;
@@ -1460,7 +1416,7 @@ sub check_zfs_get_features {
 
 	my @properties_to_check = ('createtxg');
 	foreach my $prop (@properties_to_check) {
-		my $check_prop_cmd = "$rhost $mysudocmd $zfscmd get -H $prop $empty_ds";
+		my $check_prop_cmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -H $prop $empty_ds");
 		open my $fh_p, "$check_prop_cmd 2>&1 |";
 		my $output_p = <$fh_p>;
 		close $fh_p;
@@ -1477,10 +1433,10 @@ sub check_zfs_get_features {
 
 sub iszfsbusy {
 	my ($rhost,$fs,$isroot) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
-	writelog('DEBUG', "checking to see if $fs on $rhost is already in zfs receive using $rhost $pscmd -Ao args= ...");
+	my $cmd = rhostcmd($rhost, "$pscmd -Ao args=");
+	writelog('DEBUG', "checking to see if $fs on $rhost is already in zfs receive using $cmd ...");
 
-	open PL, "$rhost $pscmd -Ao args= |";
+	open PL, "$cmd |";
 	my @processes = <PL>;
 	close PL;
 
@@ -1501,18 +1457,13 @@ sub setzfsvalue {
 
 	my $fsescaped = escapeshellparam($fs);
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	writelog('DEBUG', "setting $property to $value on $fs...");
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	writelog('DEBUG', "$rhost $mysudocmd $zfscmd set $property=$value $fsescaped");
-	system("$rhost $mysudocmd $zfscmd set $property=$value $fsescaped") == 0
-		or writelog('WARN', "$rhost $mysudocmd $zfscmd set $property=$value $fsescaped died: $?, proceeding anyway.");
+	my $cmd = rhostcmd($rhost, "$mysudocmd $zfscmd set $property=$value $fsescaped");
+	writelog('DEBUG', $cmd);
+	system($cmd) == 0
+		or writelog('WARN', "$cmd died: $?, proceeding anyway.");
 	return;
 }
 
@@ -1521,18 +1472,13 @@ sub getzfsvalue {
 
 	my $fsescaped = escapeshellparam($fs);
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	writelog('DEBUG', "getting current value of $property on $fs...");
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	writelog('DEBUG', "$rhost $mysudocmd $zfscmd get -H $property $fsescaped");
+	my $cmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -H $property $fsescaped");
+	writelog('DEBUG', $cmd);
 	my ($value, $error, $exit) = capture {
-		system("$rhost $mysudocmd $zfscmd get -H $property $fsescaped");
+		system($cmd);
 	};
 
 	my @values = split(/\t/,$value);
@@ -1554,18 +1500,13 @@ sub getlocalzfsvalues {
 
 	my $fsescaped = escapeshellparam($fs);
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	writelog('DEBUG', "getting locally set values of properties on $fs...");
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	writelog('DEBUG', "$rhost $mysudocmd $zfscmd get -s local -H all $fsescaped");
+	my $cmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -s local -H all $fsescaped");
+	writelog('DEBUG', $cmd);
 	my ($values, $error, $exit) = capture {
-		system("$rhost $mysudocmd $zfscmd get -s local -H all $fsescaped");
+		system($cmd);
 	};
 
 	my %properties=();
@@ -1694,8 +1635,6 @@ sub buildsynccmd {
 		if (length $directconnect) {
 			$synccmd .= " $socatcmd - TCP:" . $directconnect . ",retry=$directtimeout,interval=1 |";
 		}
-		$synccmd .= " $sshcmd $targethost ";
-
 		my $remotecmd = "";
 		if ($directmbuffer) {
 			$remotecmd .= " $mbuffercmd $args{'target-bwlimit'} -W $directtimeout -I " . $directlisten . " $mbufferoptions |";
@@ -1707,7 +1646,7 @@ sub buildsynccmd {
 		if ($avail{'compress'}) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
 		$remotecmd .= " $recvcmd";
 
-		$synccmd .= escapeshellparam($remotecmd);
+		$synccmd .= " " . rhostcmd($targethost, $remotecmd);
 	} elsif ($targethost eq '') {
 		# remote source, local target.
 		#$synccmd = "$sshcmd $sourcehost '$sendcmd | $compressargs{'cmd'} | $mbuffercmd' | $compressargs{'decomcmd'} | $mbuffercmd | $pvcmd | $recvcmd";
@@ -1719,7 +1658,7 @@ sub buildsynccmd {
 			$remotecmd .= " | $socatcmd - TCP:" . $directconnect . ",retry=$directtimeout,interval=1";
 		}
 
-		$synccmd = "$sshcmd $sourcehost " . escapeshellparam($remotecmd);
+		$synccmd = rhostcmd($sourcehost, $remotecmd);
 		$synccmd .= " | ";
 		if ($directmbuffer) {
 			$synccmd .= "$mbuffercmd $args{'target-bwlimit'} -W $directtimeout -I " . $directlisten . " $mbufferoptions | ";
@@ -1739,21 +1678,20 @@ sub buildsynccmd {
 		if ($avail{'compress'}) { $remotecmd .= " | $compressargs{'cmd'}"; }
 		if ($avail{'sourcembuffer'}) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
 
-		$synccmd = "$sshcmd $sourcehost " . escapeshellparam($remotecmd);
+		$synccmd = rhostcmd($sourcehost, $remotecmd);
 		$synccmd .= " | ";
 
 		if ($avail{'compress'}) { $synccmd .= "$compressargs{'decomcmd'} | "; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= "$pvcmd $pvoptions -s $pvsize | "; }
 		if ($avail{'compress'}) { $synccmd .= "$compressargs{'cmd'} | "; }
 		if ($avail{'localmbuffer'}) { $synccmd .= "$mbuffercmd $mbufferoptions | "; }
-		$synccmd .= "$sshcmd $targethost ";
 
 		$remotecmd = "";
 		if ($avail{'targetmbuffer'}) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
 		if ($avail{'compress'}) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
 		$remotecmd .= " $recvcmd";
 
-		$synccmd .= escapeshellparam($remotecmd);
+		$synccmd .= rhostcmd($targethost, $remotecmd);
 	}
 	return $synccmd;
 }
@@ -1762,8 +1700,6 @@ sub pruneoldsyncsnaps {
 	my ($rhost,$fs,$newsyncsnap,$isroot,@snaps) = @_;
 
 	my $fsescaped = escapeshellparam($fs);
-
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
 
 	my $hostid = hostname();
 
@@ -1794,12 +1730,10 @@ sub pruneoldsyncsnaps {
 		if ($counter > $maxsnapspercmd) {
 			$prunecmd =~ s/\; $//;
 			writelog('DEBUG', "pruning up to $maxsnapspercmd obsolete sync snapshots...");
-			writelog('DEBUG', "$rhost $prunecmd");
-			if ($rhost ne '') {
-				$prunecmd = escapeshellparam($prunecmd);
-			}
-			system("$rhost $prunecmd") == 0
-				or writelog('WARN', "$rhost $prunecmd failed: $?");
+			my $cmd = rhostcmd($rhost, $prunecmd);
+			writelog('DEBUG', $cmd);
+			system($cmd) == 0
+				or writelog('WARN', "$cmd failed: $?");
 			$prunecmd = '';
 			$counter = 0;
 		}
@@ -1809,12 +1743,10 @@ sub pruneoldsyncsnaps {
 	if ($counter) {
 		$prunecmd =~ s/\; $//;
 		writelog('DEBUG', "pruning up to $maxsnapspercmd obsolete sync snapshots...");
-		writelog('DEBUG', "$rhost $prunecmd");
-		if ($rhost ne '') {
-			$prunecmd = escapeshellparam($prunecmd);
-		}
-		system("$rhost $prunecmd") == 0
-			or writelog('WARN', "$rhost $prunecmd failed: $?");
+		my $cmd = rhostcmd($rhost, $prunecmd);
+		writelog('DEBUG', $cmd);
+		system($cmd) == 0
+			or writelog('WARN', "$cmd failed: $?");
 	}
 	return;
 }
@@ -1835,19 +1767,14 @@ sub getmatchingsnapshot {
 sub newsyncsnap {
 	my ($rhost,$fs,$isroot) = @_;
 	my $fsescaped = escapeshellparam($fs);
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 	my $hostid = hostname();
 	my %date = getdate();
 	my $snapname = "syncoid\_$identifier$hostid\_$date{'stamp'}";
-	my $snapcmd = "$rhost $mysudocmd $zfscmd snapshot $fsescaped\@$snapname\n";
+	my $snapcmd = rhostcmd($rhost, "$mysudocmd $zfscmd snapshot $fsescaped\@$snapname");
 	writelog('DEBUG', "creating sync snapshot using \"$snapcmd\"...");
-	system($snapcmd) == 0 or do {
+	system("$snapcmd\n") == 0 or do {
 		writelog('CRITICAL', "$snapcmd failed: $?");
 		if ($exitcode < 2) { $exitcode = 2; }
 		return 0;
@@ -1859,14 +1786,9 @@ sub newsyncsnap {
 sub targetexists {
 	my ($rhost,$fs,$isroot) = @_;
 	my $fsescaped = escapeshellparam($fs);
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	my $checktargetcmd = "$rhost $mysudocmd $zfscmd get -H name $fsescaped";
+	my $checktargetcmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -H name $fsescaped");
 	writelog('DEBUG', "checking to see if target filesystem exists using \"$checktargetcmd 2>&1 |\"...");
 	open FH, "$checktargetcmd 2>&1 |";
 	my $targetexists = <FH>;
@@ -1962,12 +1884,6 @@ sub getsnaps {
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	my $host_features = check_zfs_get_features($rhost, $mysudocmd, $zfscmd);
 
 	my @properties = @{$host_features->{supported_properties}};
@@ -1978,7 +1894,7 @@ sub getsnaps {
 		push @properties, 'type';
 	}
 	my $properties_string = join(',', @properties);
-	my $getsnapcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 $type_filter $properties_string $fsescaped";
+	my $getsnapcmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -Hpd 1 $type_filter $properties_string $fsescaped");
 
 	if ($debug) {
 		$getsnapcmd = "$getsnapcmd |";
@@ -2043,18 +1959,12 @@ sub getbookmarks() {
 	my $fsescaped = escapeshellparam($fs);
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	my $host_features = check_zfs_get_features($rhost, $mysudocmd, $zfscmd);
 	my @properties = @{$host_features->{supported_properties}};
 	my $properties_string = join(',', @properties);
 
 	my $error = 0;
-	my $getbookmarkcmd = "$rhost $mysudocmd $zfscmd get -Hpd 1 -t bookmark $properties_string $fsescaped 2>&1 |";
+	my $getbookmarkcmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -Hpd 1 -t bookmark $properties_string $fsescaped") . " 2>&1 |";
 	writelog('DEBUG', "getting list of bookmarks on $fs using $getbookmarkcmd...");
 	open FH, $getbookmarkcmd;
 	my @rawbookmarks = <FH>;
@@ -2121,15 +2031,6 @@ sub getsendsize {
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
 
-	my $sourcessh;
-	if ($sourcehost ne '') {
-		$sourcessh = "$sshcmd $sourcehost";
-		$snap1escaped = escapeshellparam($snap1escaped);
-		$snap2escaped = escapeshellparam($snap2escaped);
-	} else {
-		$sourcessh = '';
-	}
-
 	my $snaps;
 	if ($snap2) {
 		# if we got a $snap2 argument, we want an incremental send estimate from $snap1 to $snap2.
@@ -2151,7 +2052,7 @@ sub getsendsize {
 	} else {
 		$sendoptions = getoptionsline(\@sendoptions, ('L','V','R','X','b','c','e','h','p','s','w'));
 	}
-	my $getsendsizecmd = "$sourcessh $mysudocmd $zfscmd send $sendoptions -nvP $snaps";
+	my $getsendsizecmd = rhostcmd($sourcehost, "$mysudocmd $zfscmd send $sendoptions -nvP $snaps");
 	writelog('DEBUG', "getting estimated transfer size from source $sourcehost using \"$getsendsizecmd 2>&1 |\"...");
 
 	open FH, "$getsendsizecmd 2>&1 |";
@@ -2228,6 +2129,14 @@ sub escapeshellparam {
 	}
 	# single-quote entire string
 	return "'$par'";
+}
+
+sub rhostcmd {
+	my ($rhost, $cmd) = @_;
+	if ($rhost ne '') {
+		return "$sshcmd $rhost " . escapeshellparam($cmd);
+	}
+	return $cmd;
 }
 
 sub getreceivetoken() {
@@ -2309,18 +2218,12 @@ sub resetreceivestate {	my ($rhost,$fs,$isroot) = @_;
 
 	my $fsescaped = escapeshellparam($fs);
 
-	if ($rhost ne '') {
-		$rhost = "$sshcmd $rhost";
-		# double escaping needed
-		$fsescaped = escapeshellparam($fsescaped);
-	}
-
 	writelog('DEBUG', "reset partial receive state of $fs...");
 	my $mysudocmd;
 	if ($isroot) { $mysudocmd = ''; } else { $mysudocmd = $sudocmd; }
-	my $resetcmd = "$rhost $mysudocmd $zfscmd receive -A $fsescaped";
-	writelog('DEBUG', "$resetcmd");
-	system("$resetcmd") == 0
+	my $resetcmd = rhostcmd($rhost, "$mysudocmd $zfscmd receive -A $fsescaped");
+	writelog('DEBUG', $resetcmd);
+	system($resetcmd) == 0
 		or die "CRITICAL ERROR: $resetcmd failed: $?";
 }
 


### PR DESCRIPTION
## Motivation and Context

This pull request is a more robust alternative to https://github.com/jimsalterjrs/sanoid/pull/1086, which fixes https://github.com/jimsalterjrs/sanoid/issues/1085 by adding a double-escape for the empty-string dataset arguments in `check_zfs_get_features()`.  That fix is correct, but it treats the symptom rather than the underlying design issue: `syncoid` relies on 35 call sites, each of which must independently remember to double-escape shell arguments for SSH, and it is easy to forget (as happened in https://github.com/jimsalterjrs/sanoid/pull/1007).

This refactoring eliminates the double-escape pattern entirely by introducing a `rhostcmd()` helper that enforces layered escaping semantics.

## Description

### refactor(syncoid): Replace double-escape pattern with `rhostcmd()` helper

The existing approach to running commands on remote hosts required each
call site to manually prepend `$sshcmd` to `$rhost` and double-escape
every shell argument with `escapeshellparam()`.  This pattern was
repeated across 35 call sites and was easy to get wrong.  The bug
fixed in https://github.com/jimsalterjrs/sanoid/pull/1086 was caused by
exactly this: `check_zfs_get_features()` forgot to double-escape its
empty-string dataset arguments, causing `zfs get` to dump every dataset
on the remote system.

This commit introduces `rhostcmd($rhost, $cmd)`, which enforces a
layered approach: Callers build the command as if it runs locally
(single-level escaping), and `rhostcmd()` handles the SSH transport
layer by wrapping the entire command as a single shell-quoted argument
to SSH.  When `$rhost` is empty (local execution), the command is
returned as is.

```perl
sub rhostcmd {
    my ($rhost, $cmd) = @_;
    if ($rhost ne '') {
        return "$sshcmd $rhost " . escapeshellparam($cmd);
    }
    return $cmd;
}
```

A typical call site goes from:

```perl
my $fsescaped = escapeshellparam($fs);
if ($rhost ne '') {
    $rhost = "$sshcmd $rhost";
    # double escaping needed
    $fsescaped = escapeshellparam($fsescaped);
}
my $cmd = "$rhost $mysudocmd $zfscmd get -H $property $fsescaped";
```

to:

```perl
my $fsescaped = escapeshellparam($fs);
my $cmd = rhostcmd($rhost, "$mysudocmd $zfscmd get -H $property $fsescaped");
```

This eliminates:

* All `$rhost = "$sshcmd $rhost"` mutations
* All `# double escaping needed` / `escapeshellparam($escaped)` blocks
* The `$sourcessh` / `$targetssh` intermediary variables
* The class of bugs where a new call site forgets to double-escape

Supersedes: https://github.com/jimsalterjrs/sanoid/pull/1086
Fixes: https://github.com/jimsalterjrs/sanoid/issues/1085

## Related Issues

* https://github.com/jimsalterjrs/sanoid/issues/1085 – The bug this fixes (empty-string args in `check_zfs_get_features()` not surviving SSH)
* https://github.com/jimsalterjrs/sanoid/pull/1086 – The targeted fix for the same bug; this pull request supersedes it with a broader refactoring
* https://github.com/jimsalterjrs/sanoid/pull/1007 – The pull request that introduced `check_zfs_get_features()` and the bug

## How Has This Been Tested?

### Correctness

Using a test harness that extracts `check_zfs_get_features()` and its dependencies from two Git refs and compares results:

```
deltik@workstation [~/Documents/Development/IdeaProjects/sanoid]$ ./test_check_zfs_get_features.pl master HEAD 'ssh root@box1.deltik.net'
Before (master): supports_type_filter=1 supported_properties=[guid, creation, createtxg]
After  (HEAD):  supports_type_filter=1 supported_properties=[guid, creation, createtxg]
PASS: results match
```

#### Correctness Test Harness Source Code

<details>
<summary><code>test_check_zfs_get_features.pl</code></summary>

```perl
#!/usr/bin/perl
# Correctness test for check_zfs_get_features() across two Git refs
# Usage: ./test_check_zfs_get_features.pl <ref-before> <ref-after> <rhost>
# Exits 0 if both refs produce the same feature detection results.
use strict;
use warnings;

my $ref_before = $ARGV[0] // die "Usage: $0 <ref-before> <ref-after> <rhost>\n";
my $ref_after  = $ARGV[1] // die "Usage: $0 <ref-before> <ref-after> <rhost>\n";
my $rhost      = $ARGV[2] // '';

sub extract_and_run {
	my ($ref, $rhost) = @_;

	my $source = `git show $ref:syncoid` or die "Failed to read syncoid at $ref\n";

	my %subs;
	while ($source =~ /^(sub (escapeshellparam|check_zfs_get_features|writelog|rhostcmd) \{.*?^\})/gms) {
		$subs{$2} = $1;
	}

	die "Could not extract escapeshellparam from $ref\n"       unless $subs{escapeshellparam};
	die "Could not extract check_zfs_get_features from $ref\n" unless $subs{check_zfs_get_features};

	my $pkg = "Ref_" . ($ref =~ s/[^a-zA-Z0-9]/_/gr);
	my $code = "package $pkg; use strict; use warnings;\n";
	$code .= "our \%host_zfs_get_features;\n";
	$code .= "our \$sshcmd = '';\n";
	$code .= "sub writelog { }\n";
	$code .= "$subs{escapeshellparam}\n";
	$code .= "$subs{rhostcmd}\n" if $subs{rhostcmd};
	$code .= "$subs{check_zfs_get_features}\n";
	$code .= "1;\n";

	eval $code;
	die "Eval failed for $ref: $@\n" if $@;

	my $fn = "${pkg}::check_zfs_get_features";
	no strict 'refs';
	return $fn->($rhost, '', 'zfs');
}

my $result_before = extract_and_run($ref_before, $rhost);
my $result_after  = extract_and_run($ref_after,  $rhost);

sub format_result {
	my ($result) = @_;
	my $props = join(', ', @{$result->{supported_properties}});
	return "supports_type_filter=$result->{supports_type_filter} supported_properties=[$props]";
}

my $str_before = format_result($result_before);
my $str_after  = format_result($result_after);

print "Before ($ref_before): $str_before\n";
print "After  ($ref_after):  $str_after\n";

if ($str_before eq $str_after) {
	print "PASS: results match\n";
	exit 0;
} else {
	print "FAIL: results differ\n";
	exit 1;
}
```

</details>

### Performance

Using a benchmark harness that extracts and runs `check_zfs_get_features()` from a given Git ref:

```
deltik@workstation [~/Documents/Development/IdeaProjects/sanoid]$ hyperfine --warmup=1 './bench_check_zfs_get_features.pl master "ssh root@box1.deltik.net"' './bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net"' 
Benchmark 1: ./bench_check_zfs_get_features.pl master "ssh root@box1.deltik.net"
  Time (mean ± σ):      2.030 s ±  0.094 s    [User: 0.009 s, System: 0.011 s]
  Range (min … max):    1.909 s …  2.209 s    10 runs
 
Benchmark 2: ./bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net"
  Time (mean ± σ):     963.6 ms ±  71.4 ms    [User: 10.1 ms, System: 10.1 ms]
  Range (min … max):   881.7 ms … 1124.9 ms    10 runs
 
Summary
  ./bench_check_zfs_get_features.pl HEAD "ssh root@box1.deltik.net" ran
    2.11 ± 0.18 times faster than ./bench_check_zfs_get_features.pl master "ssh root@box1.deltik.net"
```

#### Performance Test Harness Source Code

<details>
<summary><code>bench_check_zfs_get_features.pl</code></summary>

```perl
#!/usr/bin/perl
# Benchmark harness for check_zfs_get_features() extracted from Git history
# Usage: ./bench_check_zfs_get_features.pl <git-ref> <rhost>
# Example: hyperfine './bench_check_zfs_get_features.pl HEAD~1 "ssh root@host"' \
#                     './bench_check_zfs_get_features.pl HEAD "ssh root@host"'
use strict;
use warnings;

my $ref   = $ARGV[0] // die "Usage: $0 <git-ref> <rhost>\n";
my $rhost = $ARGV[1] // '';

my $source = `git show $ref:syncoid` or die "Failed to read syncoid at $ref\n";

my %subs;
while ($source =~ /^(sub (escapeshellparam|check_zfs_get_features|writelog|rhostcmd) \{.*?^\})/gms) {
	$subs{$2} = $1;
}

die "Could not extract escapeshellparam from $ref\n"          unless $subs{escapeshellparam};
die "Could not extract check_zfs_get_features from $ref\n"    unless $subs{check_zfs_get_features};

my $code = "use strict; use warnings;\n";
$code .= "our \%host_zfs_get_features;\n";
$code .= "our \$sshcmd = '';\n";
$code .= "sub writelog { }\n";
$code .= "$subs{escapeshellparam}\n";
$code .= "$subs{rhostcmd}\n" if $subs{rhostcmd};
$code .= "$subs{check_zfs_get_features}\n";
$code .= "1;\n";

eval $code;
die "Eval failed: $@\n" if $@;

check_zfs_get_features($rhost, '', 'zfs');
```

</details>

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)