### PR TITLE
Update bandwidth limit usage

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -2414,8 +2414,8 @@ Options:
   --identifier=EXTRA    Extra identifier which is included in the snapshot name. Can be used for replicating to multiple targets.
   --recursive|r         Also transfers child datasets
   --skip-parent         Skips syncing of the parent dataset. Does nothing without '--recursive' option.
-  --source-bwlimit=<limit k|m|g|t>  Bandwidth limit in bytes/kbytes/etc per second on the source transfer
-  --target-bwlimit=<limit k|m|g|t>  Bandwidth limit in bytes/kbytes/etc per second on the target transfer
+  --source-bwlimit=<limit k|M|G|T>  Bandwidth limit in bytes/kbytes/etc per second on the source transfer (needs mbuffer)
+  --target-bwlimit=<limit k|M|G|T>  Bandwidth limit in bytes/kbytes/etc per second on the target transfer (needs mbuffer)
   --mbuffer-size=VALUE  Specify the mbuffer size (default: 16M), please refer to mbuffer(1) manual page.
   --pv-options=OPTIONS  Configure how pv displays the progress bar, default '-p -t -e -r -b'
   --no-stream           Replicates using newest snapshot instead of intermediates


### PR DESCRIPTION
As per official mbuffer man:
```
-r <rate>
Set the maximum read rate to rate. rate can be given in either Bytes, kBytes, MBytes, or GBytes per second. To do so, use an appropriate suffix (i.e. k,M,G). This option is useful if you have a tape that is capable of transferring data faster than the host can handle it. In this case you can use this option to limit the transfer rate and keep the tape running. Be aware that this is both good for your tape drive, and enhances overall performance, by avoiding tape screwing.
```

Bandwidth should be expressed with uppercase M/G/T suffixes. It should also be known that bandwidth control requires mbuffer installed.