### PR TITLE
Add Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+my $version = do {
+    open my $fh, '<', 'VERSION' or die "Cannot open VERSION: $!";
+    my $v = <$fh>;
+    close $fh;
+    $v =~ s/\s+\z//;
+    $v;
+};
+
+WriteMakefile(
+    NAME             => 'App::Sanoid',
+    ABSTRACT         => 'Policy-driven ZFS snapshot management and replication tools',
+    VERSION          => $version,
+    AUTHOR           => 'Jim Salter <jim@openoid.net>',
+    LICENSE          => 'gpl_3',
+    MIN_PERL_VERSION => '5.010',
+    EXE_FILES        => [qw(sanoid syncoid findoid sleepymutex)],
+    PREREQ_PM        => {
+        'Config::IniFiles' => 0,
+        'Capture::Tiny'    => 0,
+    },
+    META_MERGE => {
+        'meta-spec' => { version => 2 },
+        resources   => {
+            homepage   => 'https://github.com/jimsalterjrs/sanoid',
+            repository => {
+                type => 'git',
+                url  => 'https://github.com/jimsalterjrs/sanoid.git',
+                web  => 'https://github.com/jimsalterjrs/sanoid',
+            },
+            bugtracker => {
+                web => 'https://github.com/jimsalterjrs/sanoid/issues',
+            },
+        },
+    },
+);

--- a/lib/App/Sanoid.pm
+++ b/lib/App/Sanoid.pm
@@ -1,0 +1,12 @@
+package App::Sanoid;
+
+# This stub module exists so that tools like `cpanm --uninstall`
+# can locate the distribution via @INC. The actual functionality
+# lives in the sanoid, syncoid, findoid, and sleepymutex scripts.
+
+use strict;
+use warnings;
+
+our $VERSION = '2.3.0';
+
+1;


### PR DESCRIPTION
This will make it possible to install sanoid/syncoid with `cpanm https://github.com/jimsalterjrs/sanoid.git`

Useful for those on distros who don't have a native package.

I loathe having to install things from the AUR.  I always have a perl environment around.  

Something worth noting, I don't think the addition of the .pm file will impact any of the existing package configs in the repo, except debhelper printing a warning about a missing package. 