### PR TITLE
Make ssh control sockets safer against local attacks.

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -9,6 +9,8 @@ $::VERSION = '2.3.0';
 use strict;
 use warnings;
 use Data::Dumper;
+use File::Path 'make_path';
+use File::Spec;
 use Getopt::Long qw(:config auto_version auto_help);
 use Pod::Usage;
 use Time::Local;
@@ -20,15 +22,18 @@ my $pvoptions = "-p -t -e -r -b";
 
 # Blank defaults to use ssh client's default
 # TODO: Merge into a single "sshflags" option?
-my %args = ('sshconfig' => '', 'sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '');
+my %args = ('sshconfig' => '', 'sshkey' => '', 'sshport' => '', 'sshcipher' => '', 'sshoption' => [], 'target-bwlimit' => '', 'source-bwlimit' => '', 'run-dir' => '');
 GetOptions(\%args, "no-command-checks", "monitor-version", "compress=s", "dumpsnaps", "recursive|r", "sendoptions=s", "recvoptions=s",
                    "source-bwlimit=s", "target-bwlimit=s", "sshconfig=s", "sshkey=s", "sshport=i", "sshcipher|c=s", "sshoption|o=s@",
                    "debug", "quiet", "no-stream", "no-sync-snap", "no-resume", "exclude=s@", "skip-parent", "identifier=s",
                    "no-clone-handling", "no-privilege-elevation", "force-delete", "no-rollback", "create-bookmark", "use-hold",
                    "pv-options=s" => \$pvoptions, "keep-sync-snap", "preserve-recordsize", "mbuffer-size=s" => \$mbuffer_size,
                    "delete-target-snapshots", "insecure-direct-connection=s", "preserve-properties",
-                   "include-snaps=s@", "exclude-snaps=s@", "exclude-datasets=s@")
+                   "include-snaps=s@", "exclude-snaps=s@", "exclude-datasets=s@", "run-dir=s")
                    or pod2usage(2);
+
+# Figure out a path to place ssh control sockets.
+my $run_dir = getruntimedir($<, $args{'run-dir'});
 
 my %compressargs = %{compressargset($args{'compress'} || 'default')}; # Can't be done with GetOptions arg, as default still needs to be set
 
@@ -317,6 +322,70 @@ exit $exitcode;
 ##############################################################################
 ##############################################################################
 ##############################################################################
+
+# Try to return a somewhat safe directory to store sockets.
+# We want to avoid /tmp if all possible as it is world writable, and exposes
+# the sockets to be guessed, and abused by attackers.
+# Note that this code does not provide any guarantee that the resulting path
+# will be safer than /tmp (as it cannot do so without introducing some TOCTOU
+# race), but in a well configured system it should provide a safer path. It
+# will typically be no worse than /tmp, and it will return /tmp if nothing
+# better can be found.
+# See https://0pointer.net/blog/projects/tmp.html for a discussion where to
+# store sockets.
+sub getruntimedir {
+	my ($localuid,$run_dir) = @_;
+	# Array containing a list ($dir, $create_subdir) where:
+	# - $dir is a candidate for a directory to be used as a runtime dir for
+	# ssh control sockets.
+	# - $create_subdir: whether a subdirectory ought to be created inside
+	# this directory (named syncoid) to store the sockets.
+	my @candidates;
+
+	# If the user provided a runtime dir trust it, and we do not create
+	# a specific subdir to store the sockets.
+	if ($run_dir) {
+		make_path($run_dir);
+		push(@candidates, [$run_dir, 0]);
+	}
+	# Consider other candidates depending on whether we run as root or not.
+	if ($localuid == 0) {
+		push(@candidates, (["/run", 1],
+				   ["/var/run", 1]));
+	} else {
+		# Per glib implementation, build_user_runtime_dir tries:
+		# - XDG_RUNTIME_DIR
+		# - XDG_CACHE_HOME
+		# - $HOME/.cache if XDG_CACHE_HOME is not set (following XDG
+		#   Base Directory spec)
+		push(@candidates, ([$ENV{"XDG_RUNTIME_DIR"}, 1],
+				   [$ENV{"XDG_CACHE_HOME"}, 1],
+				   [File::Spec->catfile($ENV{"HOME"}, ".cache"), 1]
+		     ));
+	}
+    
+	foreach my $candidate (@candidates) {
+		my $dir = @$candidate[0];
+		my $create_subdir = @$candidate[1];
+		# Avoid directories that do not exist and are not properly
+		# configured.
+		if (defined $dir and $dir ne "" and -d $dir and -w $dir) {
+			if ($create_subdir == 1) {
+				$dir = File::Spec->catfile($dir, "syncoid");
+				make_path($dir, {error => \my $err});
+				if ($err and @$err) {
+					writelog('INFO', "Could not create subdir $dir, skipping");
+					next;
+				}
+			}
+			return $dir;
+		}
+	}
+	# We could not find anything, default to the legacy behavior of using
+	# /tmp.
+	writelog('WARN', 'Using legacy potentially insecure /tmp to store ssh control sockets, consider passing a non world writable --run-dir parameter.');
+	return "/tmp";
+}
 
 sub getchilddatasets {
 	my ($rhost,$fs,$isroot,%snaps) = @_;
@@ -1925,7 +1994,7 @@ sub getssh {
 		$sanitizedrhost = substr($sanitizedrhost, 0, 50);
 
 		# now we need to establish a persistent master SSH connection
-		$socket = "/tmp/syncoid-$sanitizedrhost-" . time() . "-" . $$ . "-" . int(rand(10000));
+		$socket = File::Spec->catfile($run_dir, "syncoid-$sanitizedrhost-" . time() . "-" . $$ . "-" . int(rand(10000)));
 
 
 		open FH, "$sshcmd -M -S $socket -o ControlPersist=1m $args{'sshport'} $rhost exit |";
@@ -2377,7 +2446,8 @@ sub buildnicename {
 
 	my $name;
 	if ($host) {
-		$host =~ s/-S \/tmp\/syncoid[a-zA-Z0-9-@]+ //g;
+		my $socket_re = '-S ' . quotemeta(File::Spec->catfile($run_dir, 'syncoid')) . '[a-zA-Z0-9-@]+ ';
+		$host =~ s/$socket_re//g;
 		$name = "$host:$fs";
 	} else {
 		$name = "$fs";
@@ -2438,6 +2508,7 @@ Options:
   --sshport=PORT        Connects to remote on a particular port
   --sshcipher|c=CIPHER  Passes CIPHER to ssh to use a particular cipher set
   --sshoption|o=OPTION  Passes OPTION to ssh for remote usage. Can be specified multiple times
+  --run-dir=DIR         Specify a directory for ssh sockets. For security reasons, this should be a non world writable directory. If left empty, it will try to find a reasonable directory and fault back to the somewhat unsafe /tmp if nothing suitable is found.
   --insecure-direct-connection=IP:PORT[,IP:PORT]  WARNING: DATA IS NOT ENCRYPTED. First address pair is for connecting to the target and the second for listening at the target
 
   --help                Prints this helptext


### PR DESCRIPTION
The current control sockets are placed in /tmp, a path writable to any
local account. If the socket name is guessed, it is possible to mount an
attack by which the sockets are created in advance, and traffic is then
intercepted. This is why it is recommended that such sockets are never
placed inside paths accessible to others (see https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Multiplexing#Additional_Notes_About_Multiplexing).

The current code mitigates this attack by having the time() as well as
some random number (among 10k possibilities). However, given that syncoid
jobs will likely be run at guessable times (since one common usage is
to run these in crons), the entropy of the socket name is not that large
and it becomes relatively easy for an attacker to hijack such sockets.
Instead of increasing the entropy pool from 10k to a larger value, it is
more robust to store such sockets in places that are writable only to the
user running the syncoid job.
Following https://0pointer.net/blog/projects/tmp.html, the new code will
make use of $XDG_RUNTIME_DIR/, /run or /var/run depending on the user
running syncoid and configuration.

As a result, on well configured systems, this closes the attack surface.
Because not all Unix systems though follow XDG, or the usage of /run,
this commit will default to use the legacy (and potentially unsafe per
above) /tmp if nothing is found, and encourage users to specify their
preferred run time dir using --run-dir similarly to what is proposed
inside sanoid.

This was tested by running a syncoid between two machines and
observing that the sockets were no longer in /tmp/syncoid... but
instead in XDG_.../syncoid directory.
