### PR TITLE
syncoid: release stale holds left by a re-created target or an interrupted run

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -691,6 +691,15 @@ sub syncdataset {
 		if ($matchingsnap eq $newsyncsnap) {
 			# barf some text but don't touch the filesystem
 			writelog('INFO', "no snapshots on source newer than $newsyncsnap on target. Nothing to do, not syncing.");
+			# Holds outlive replication: sweep here too, otherwise a dataset that
+			# stopped producing snapshots keeps any stale hold for good - this
+			# branch returns before the --use-hold block below is ever reached.
+			if (defined $args{'use-hold'}) {
+				my $hostid = hostname();
+				my $holdname = "syncoid\_$identifier$hostid";
+				releasestaleholds($sourcehost,$sourcefs,$sourceisroot,$holdname,$newsyncsnap);
+				releasestaleholds($targethost,$targetfs,$targetisroot,$holdname,$newsyncsnap);
+			}
 			return 0;
 		} else {
 			my $matchingsnapescaped = escapeshellparam($matchingsnap);
@@ -839,6 +848,7 @@ sub syncdataset {
 			writelog('DEBUG', "Release old hold on source: $holdreleasecmd");
 			system($holdreleasecmd) == 0 or warn "WARNING: $holdreleasecmd failed: $?";
 		}
+		releasestaleholds($sourcehost,$sourcefs,$sourceisroot,$holdname,$newsyncsnap,$matchingsnap);
 		if ($targethost ne '') {
 			$holdcmd = "$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd hold $holdname $targetfsescaped\@$newsyncsnapescaped");
 			$holdreleasecmd = "$sshcmd $targethost " . escapeshellparam("$targetsudocmd $zfscmd release $holdname $targetfsescaped\@$matchingsnapescaped");
@@ -852,6 +862,7 @@ sub syncdataset {
 			writelog('DEBUG', "Release old hold on target: $holdreleasecmd");
 			system($holdreleasecmd) == 0 or warn "WARNING: $holdreleasecmd failed: $?";
 		}
+		releasestaleholds($targethost,$targetfs,$targetisroot,$holdname,$newsyncsnap,$matchingsnap);
 	}
 	if (defined $args{'no-sync-snap'}) {
 		if (defined $args{'create-bookmark'}) {
@@ -2105,6 +2116,110 @@ sub getbookmarks() {
 	}
 
 	return %bookmarks;
+}
+
+sub releasestaleholds {
+	# Release every hold carrying our own hold name on $fs, except the ones
+	# protecting the snapshots in @keep: the snapshot just sent, and the common
+	# base it was sent from. Holds never expire, so a replication with no common
+	# base to release from - a full re-seed after the target was destroyed - or a
+	# run interrupted between the hold and the release leaves its previous anchor
+	# behind forever, pinning a snapshot no later run will ever free.
+	#
+	# Only holds under our exact hold name are considered: other identifiers
+	# belong to other replication relations. Enumerating what is actually there,
+	# instead of releasing blindly, also keeps the very first replication of a
+	# dataset quiet - there is nothing to release, so no "no such tag" error.
+	my ($rhost,$fs,$isroot,$holdname,@keep) = @_;
+
+	my %keep;
+	foreach my $snap (@keep) {
+		if (defined $snap && length $snap) { $keep{$snap} = 1; }
+	}
+
+	my $mysudocmd = $isroot ? '' : $sudocmd;
+	my $fsescaped = escapeshellparam($fs);
+
+	# userrefs is the number of holds on a snapshot: it narrows the list handed
+	# to `zfs holds` down to the few snapshots that are actually held.
+	my $getuserrefscmd = "$mysudocmd $zfscmd get -Hpd 1 -o name,value userrefs $fsescaped";
+	if ($rhost ne '') {
+		$getuserrefscmd = "$sshcmd $rhost " . escapeshellparam($getuserrefscmd);
+	}
+	writelog('DEBUG', "Listing held snapshots on $fs: $getuserrefscmd");
+	if ($debug) {
+		$getuserrefscmd = "$getuserrefscmd |";
+	} else {
+		$getuserrefscmd = "$getuserrefscmd 2>/dev/null |";
+	}
+	open FH, $getuserrefscmd;
+	my @rawuserrefs = <FH>;
+	close FH;
+
+	my @heldsnaps;
+	foreach my $line (@rawuserrefs) {
+		chomp $line;
+		my ($dataset, $userrefs) = split /\t/, $line;
+		next unless defined $userrefs && $userrefs =~ /^[1-9][0-9]*$/;
+		# belt and braces: never look past the dataset we were handed
+		next unless $dataset =~ /^\Q$fs\E\@/;
+		my (undef, $snap) = split /\@/, $dataset, 2;
+		next unless defined $snap && length $snap;
+		push @heldsnaps, $snap;
+	}
+	return if !@heldsnaps;
+
+	my $getholdscmd = "$mysudocmd $zfscmd holds -H";
+	foreach my $snap (@heldsnaps) {
+		$getholdscmd .= ' ' . escapeshellparam("$fs\@$snap");
+	}
+	if ($rhost ne '') {
+		$getholdscmd = "$sshcmd $rhost " . escapeshellparam($getholdscmd);
+	}
+	writelog('DEBUG', "Listing holds on $fs: $getholdscmd");
+	if ($debug) {
+		$getholdscmd = "$getholdscmd |";
+	} else {
+		$getholdscmd = "$getholdscmd 2>/dev/null |";
+	}
+	open FH, $getholdscmd;
+	my @rawholds = <FH>;
+	close FH;
+
+	my @stalesnaps;
+	my $anchored = 0;
+	foreach my $line (@rawholds) {
+		chomp $line;
+		my ($dataset, $tag) = split /\t/, $line;
+		next unless defined $tag && $tag eq $holdname;
+		next unless $dataset =~ /^\Q$fs\E\@/;
+		my (undef, $snap) = split /\@/, $dataset, 2;
+		next unless defined $snap && length $snap;
+		if (exists $keep{$snap}) {
+			$anchored = 1;
+		} else {
+			push @stalesnaps, $snap;
+		}
+	}
+	return if !@stalesnaps;
+
+	# Never release the last anchor: if the hold on the snapshot just sent is
+	# missing, placing it failed, and releasing the older one would leave the
+	# common base unprotected from pruning.
+	if (!$anchored) {
+		warn "WARNING: leaving " . scalar(@stalesnaps) . " stale $holdname hold(s) on $fs: no hold on the current snapshot to replace them";
+		return;
+	}
+
+	foreach my $snap (@stalesnaps) {
+		my $snapescaped = escapeshellparam($snap);
+		my $releasecmd = "$mysudocmd $zfscmd release $holdname $fsescaped\@$snapescaped";
+		if ($rhost ne '') {
+			$releasecmd = "$sshcmd $rhost " . escapeshellparam($releasecmd);
+		}
+		writelog('DEBUG', "Release stale hold: $releasecmd");
+		system($releasecmd) == 0 or warn "WARNING: $releasecmd failed: $?";
+	}
 }
 
 sub getsendsize {


### PR DESCRIPTION
Implements the improvement @jjakob suggested when closing #1099: keep the hold
on the common snapshot and on the last snapshot sent, release every other hold
carrying the same identifier.

Reported with measurements in #1109.

## The problem

Under `--use-hold`, syncoid places a hold on the snapshot it just sent, then
releases the one on the common snapshot -- but the release is guarded by the
existence of that common snapshot:

```perl
system($holdcmd) == 0 or warn "WARNING: $holdcmd failed: $?";
# Do hold release only if matchingsnap exists
if ($matchingsnap) {
    system($holdreleasecmd) == 0 or warn "WARNING: $holdreleasecmd failed: $?";
}
```

Two situations skip that release, and neither is recovered by any later run:

1. **A re-created target.** When the target has been destroyed and re-created
   there is no common snapshot, so `$matchingsnap` is undefined and the
   previous hold stays. A first replication is a full send too, but carries no
   previous hold to leak -- this is the case #849 is about, and it stays
   quiet. The next run releases the hold on the base it actually used,
   never the one that was skipped.
2. **An interrupted run.** An interruption between the hold and the release
   leaves the old hold behind, permanently.

Holds do not expire. Each occurrence pins a snapshot the snapshot manager can
no longer prune, and the residue accumulates for the life of the dataset.

Measured on a production host, twice four days apart, across two pools and 70
holds: exactly two `(dataset, tag)` pairs carried more than one hold, both on
the same dataset, both dated the day of a manual remediation that destroyed
the target and replicated it again from scratch. The nominal path does not leak; the exceptional paths do.

## The change

A new `releasestaleholds()` is called after each successful replication, for
the source and for the target. It enumerates the holds actually present under
its **own** hold name, keeps the snapshot just sent and the common snapshot, and
releases the rest.

It is also called on the "nothing to send" path. That branch returns before the
`--use-hold` block is ever reached, so a dataset that stops producing snapshots
-- autosnap removed, source frozen -- would otherwise keep a stale hold for
good. There the snapshot just sent is the only keeper, and the safeguard below
needs no change: the hold on it was placed by the previous run.

Three properties are deliberate:

- **The `if ($matchingsnap)` guard is kept.** #849 documents why it exists: an
  unconditional release makes the first replication of a dataset print
  `cannot release hold ... no such tag` and then a `WARNING ... failed: 256`
  that reads as a replication failure. Enumerating instead of releasing
  blindly preserves that: on a first run the only hold present is the one just
  placed, which is a keeper, so nothing is attempted and nothing is printed.
- **No new command-line option.** Automatic behaviour was preferred over
  another flag in the review of #1068.
- **Source and target are handled symmetrically.** Stale holds on the
  receiving side are the ones that block a `-F` rollback and stall a receive.

A safeguard of its own: if neither the snapshot just sent nor the common snapshot
carries our hold -- meaning placing it failed -- nothing is released and a
warning is printed. Without it, a failed hold followed by a sweep would leave
the common snapshot unprotected from pruning.

Enumeration costs one `zfs get ... userrefs` per dataset per side, plus one
`zfs holds` only when some snapshot is actually held. `userrefs` narrows the
argument list to the few held snapshots rather than passing every snapshot of
the dataset.

## One caveat worth stating

This change makes `--identifier` uniqueness load-bearing. Two relations
sharing a hold name on the same source dataset previously just contended when
placing holds; now the run of one will actively release the hold of the other.
The existing comment above the block already assumes one identifier per
target, but replicating the same dataset to two targets without
`--identifier` is now a configuration that can cost a common snapshot.

## Testing

A bench on file-backed pools, running the same binary with and without the
patch, on the local and on the remote code path (four passes). Both columns
agree everywhere except the two generators and the safeguard:

| Scenario | Without | With |
|---|---|---|
| First replication of a fresh dataset | no `cannot release hold`, no `failed: 256` | same -- #849 not regressed |
| Nominal incremental | one hold per side | same |
| Stale hold left by an interrupted run | kept | released |
| Target destroyed, then replicated in full | holds accumulate | one hold |
| Hold under a foreign tag | untouched | untouched |
| `zfs hold` made to fail | orphan kept, silent | orphan kept, warning printed |

The "nothing to send" path was benched separately, with three columns built
from the same base: unpatched, patched without that call site, patched with it.
The first two keep the stale hold after an empty run, the third releases it --
so the middle column isolates exactly what that call site adds. The witness
that the branch was actually taken greps stdout for `Nothing to do, not
syncing`, not stderr: `writelog` prints `INFO` through `print` and only routes
`WARN` and `CRITICAL` through `warn`.

Then in production: the two residual holds mentioned above were deliberately
left in place as a witness -- same dataset, same day, one per target, only one
of the two targets online. After the first patched run the online target's
2-month-old orphan was released, the offline target's two holds were untouched,
and no `(dataset, tag)` pair lost a hold without gaining one.

Implements the specification in #1099 (closed, unrelated cause -- see #1109
for the leak on an unrestricted setup). Does not regress #849. Touches the
same lines as #1068 but is orthogonal to it.
