### PR TITLE
syncoid: filter the zfs receive check on the remote side

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -1472,10 +1472,17 @@ sub check_zfs_get_features {
 
 sub iszfsbusy {
 	my ($rhost,$fs,$isroot) = @_;
-	if ($rhost ne '') { $rhost = "$sshcmd $rhost"; }
-	writelog('DEBUG', "checking to see if $fs on $rhost is already in zfs receive using $rhost $pscmd -Ao args= ...");
 
-	open PL, "$rhost $pscmd -Ao args= |";
+	# filter on the remote side - we only care about zfs receive processes, and shipping an
+	# entire process table over ssh (three times per dataset) costs far more than the check
+	my $pipeline = "$pscmd -Ao args= | grep -e 'zfs *receive' -e 'zfs *recv'";
+	if ($rhost ne '') {
+		$rhost = "$sshcmd $rhost";
+		$pipeline = escapeshellparam($pipeline);
+	}
+	writelog('DEBUG', "checking to see if $fs on $rhost is already in zfs receive using $rhost $pipeline ...");
+
+	open PL, "$rhost $pipeline |";
 	my @processes = <PL>;
 	close PL;
 


### PR DESCRIPTION
iszfsbusy() ships the target host's entire process table over ssh and regex matches it locally, to answer one boolean: is a zfs receive already running for this dataset. It runs three times per dataset, so a recursive run over 100 datasets moves 300 full process tables. On a Proxmox host with dozens of guests that is hundreds of KB per call, and it dominates the runtime of runs that transfer little data.

This moves the grep to the remote side. Matching logic and all three call sites unchanged.

Measured on a 100 dataset recursive push between two hypervisors: per dataset wall time dropped noticeably with no behaviour change. Note sanoid dropped its own iszfsbusy check for the same reason (see CHANGELIST 2.3.0, @sdettmer); this keeps syncoid's check but stops paying for it.