### PR TITLE
syncoid: skip compression and mbuffer for tiny transfers

### DIFF
--- a/syncoid
+++ b/syncoid
@@ -17,6 +17,8 @@ use Capture::Tiny ':all';
 
 my $mbuffer_size = "16M";
 my $pvoptions = "-p -t -e -r -b";
+# transfers smaller than this skip compression and mbuffer entirely - see buildsynccmd()
+my $minpipesize = 1024*1024;
 
 # Blank defaults to use ssh client's default
 # TODO: Merge into a single "sshflags" option?
@@ -1664,6 +1666,15 @@ sub buildsynccmd {
 	# AND recompress across the pipe viewer. FUN.
 	my $synccmd;
 
+	# for tiny transfers the pipeline costs more than it saves: each mbuffer reserves
+	# $mbuffer_size up front, on both ends, to move a few KB. a pvsize of 0 means the
+	# size is unknown, so keep the pipeline in that case.
+	my $usepipe = ($pvsize == 0 || $pvsize >= $minpipesize);
+	my $compress = $avail{'compress'} && $usepipe;
+	my $srcbuffer = $avail{'sourcembuffer'} && $usepipe;
+	my $dstbuffer = $avail{'targetmbuffer'} && $usepipe;
+	my $localbuffer = $avail{'localmbuffer'} && $usepipe;
+
 	if ($sourcehost eq '' && $targethost eq '') {
 		# both sides local. don't compress. do mbuffer, once, on the source side.
 		# $synccmd = "$sendcmd | $mbuffercmd | $pvcmd | $recvcmd";
@@ -1676,7 +1687,7 @@ sub buildsynccmd {
 			$bwlimit = $args{'target-bwlimit'};
 		}
 
-		if ($avail{'sourcembuffer'}) { $synccmd .= " $mbuffercmd $bwlimit $mbufferoptions |"; }
+		if ($srcbuffer) { $synccmd .= " $mbuffercmd $bwlimit $mbufferoptions |"; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= " $pvcmd $pvoptions -s $pvsize |"; }
 		$synccmd .= " $recvcmd";
 	} elsif ($sourcehost eq '') {
@@ -1684,8 +1695,8 @@ sub buildsynccmd {
 		#$synccmd = "$sendcmd | $pvcmd | $compressargs{'cmd'} | $mbuffercmd | $sshcmd $targethost '$compressargs{'decomcmd'} | $mbuffercmd | $recvcmd'";
 		$synccmd = "$sendcmd |";
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= " $pvcmd $pvoptions -s $pvsize |"; }
-		if ($avail{'compress'}) { $synccmd .= " $compressargs{'cmd'} |"; }
-		if ($avail{'sourcembuffer'}) { $synccmd .= " $mbuffercmd $args{'source-bwlimit'} $mbufferoptions |"; }
+		if ($compress) { $synccmd .= " $compressargs{'cmd'} |"; }
+		if ($srcbuffer) { $synccmd .= " $mbuffercmd $args{'source-bwlimit'} $mbufferoptions |"; }
 		if (length $directconnect) {
 			$synccmd .= " $socatcmd - TCP:" . $directconnect . ",retry=$directtimeout,interval=1 |";
 		}
@@ -1698,8 +1709,8 @@ sub buildsynccmd {
 			$remotecmd .= " busybox nc -l " . $directlisten . " -w $directtimeout |";
 		}
 
-		if ($avail{'targetmbuffer'} && !$directmbuffer) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
-		if ($avail{'compress'}) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
+		if ($dstbuffer && !$directmbuffer) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
+		if ($compress) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
 		$remotecmd .= " $recvcmd";
 
 		$synccmd .= escapeshellparam($remotecmd);
@@ -1708,8 +1719,8 @@ sub buildsynccmd {
 		#$synccmd = "$sshcmd $sourcehost '$sendcmd | $compressargs{'cmd'} | $mbuffercmd' | $compressargs{'decomcmd'} | $mbuffercmd | $pvcmd | $recvcmd";
 
 		my $remotecmd = $sendcmd;
-		if ($avail{'compress'}) { $remotecmd .= " | $compressargs{'cmd'}"; }
-		if ($avail{'sourcembuffer'}) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
+		if ($compress) { $remotecmd .= " | $compressargs{'cmd'}"; }
+		if ($srcbuffer) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
 		if (length $directconnect) {
 			$remotecmd .= " | $socatcmd - TCP:" . $directconnect . ",retry=$directtimeout,interval=1";
 		}
@@ -1722,8 +1733,8 @@ sub buildsynccmd {
 			$synccmd .= " busybox nc -l " . $directlisten . " -w $directtimeout | ";
 		}
 
-		if ($avail{'targetmbuffer'} && !$directmbuffer) { $synccmd .= "$mbuffercmd $args{'target-bwlimit'} $mbufferoptions | "; }
-		if ($avail{'compress'}) { $synccmd .= "$compressargs{'decomcmd'} | "; }
+		if ($dstbuffer && !$directmbuffer) { $synccmd .= "$mbuffercmd $args{'target-bwlimit'} $mbufferoptions | "; }
+		if ($compress) { $synccmd .= "$compressargs{'decomcmd'} | "; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= "$pvcmd $pvoptions -s $pvsize | "; }
 		$synccmd .= "$recvcmd";
 	} else {
@@ -1731,21 +1742,21 @@ sub buildsynccmd {
 		#$synccmd = "$sshcmd $sourcehost '$sendcmd | $compressargs{'cmd'} | $mbuffercmd' | $compressargs{'decomcmd'} | $pvcmd | $compressargs{'cmd'} | $mbuffercmd | $sshcmd $targethost '$compressargs{'decomcmd'} | $mbuffercmd | $recvcmd'";
 
 		my $remotecmd = $sendcmd;
-		if ($avail{'compress'}) { $remotecmd .= " | $compressargs{'cmd'}"; }
-		if ($avail{'sourcembuffer'}) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
+		if ($compress) { $remotecmd .= " | $compressargs{'cmd'}"; }
+		if ($srcbuffer) { $remotecmd .= " | $mbuffercmd $args{'source-bwlimit'} $mbufferoptions"; }
 
 		$synccmd = "$sshcmd $sourcehost " . escapeshellparam($remotecmd);
 		$synccmd .= " | ";
 
-		if ($avail{'compress'}) { $synccmd .= "$compressargs{'decomcmd'} | "; }
+		if ($compress) { $synccmd .= "$compressargs{'decomcmd'} | "; }
 		if ($avail{'localpv'} && !$quiet) { $synccmd .= "$pvcmd $pvoptions -s $pvsize | "; }
-		if ($avail{'compress'}) { $synccmd .= "$compressargs{'cmd'} | "; }
-		if ($avail{'localmbuffer'}) { $synccmd .= "$mbuffercmd $mbufferoptions | "; }
+		if ($compress) { $synccmd .= "$compressargs{'cmd'} | "; }
+		if ($localbuffer) { $synccmd .= "$mbuffercmd $mbufferoptions | "; }
 		$synccmd .= "$sshcmd $targethost ";
 
 		$remotecmd = "";
-		if ($avail{'targetmbuffer'}) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
-		if ($avail{'compress'}) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
+		if ($dstbuffer) { $remotecmd .= " $mbuffercmd $args{'target-bwlimit'} $mbufferoptions |"; }
+		if ($compress) { $remotecmd .= " $compressargs{'decomcmd'} |"; }
 		$remotecmd .= " $recvcmd";
 
 		$synccmd .= escapeshellparam($remotecmd);

--- a/tests/syncoid/015_min_pipe_size/run.sh
+++ b/tests/syncoid/015_min_pipe_size/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# unit test for buildsynccmd(): transfers below $minpipesize must skip compression
+# and mbuffer, larger ones (and unknown-size ones) must keep the full pipeline.
+# no zpool needed - the sub is extracted from syncoid and evaluated directly.
+
+set -e
+
+exec perl -x "$0" ../../../syncoid
+exit $?
+
+#!perl
+use strict;
+use warnings;
+
+my $syncoid = shift or die "usage: run.sh /path/to/syncoid\n";
+
+# globals buildsynccmd() reads, set up to mimic a real run
+our ($sourcehost, $targethost) = ('', 'root@target');
+our %avail = ('compress' => 1, 'sourcembuffer' => 1, 'targetmbuffer' => 1, 'localmbuffer' => 1, 'localpv' => 1);
+our %args = ('source-bwlimit' => '', 'target-bwlimit' => '');
+our %compressargs = ('cmd' => 'lzop', 'decomcmd' => 'lzop -dfc');
+our $mbuffercmd = 'mbuffer';
+our $mbufferoptions = '-q -s 128k -m 16M';
+our $pvcmd = 'pv';
+our $pvoptions = '-p -t -e -r -b';
+our $socatcmd = 'socat';
+our $sshcmd = 'ssh';
+our $quiet = 0;
+our ($directconnect, $directlisten, $directtimeout, $directmbuffer) = ('', '', 60, 0);
+our $minpipesize;
+
+# pull buildsynccmd(), escapeshellparam() and $minpipesize out of syncoid itself,
+# so this test breaks if the real implementation changes behaviour
+open my $fh, '<', $syncoid or die "cannot read $syncoid: $!";
+my $src = do { local $/; <$fh> };
+close $fh;
+
+my ($size) = $src =~ /^my \$minpipesize = (.*);$/m or die "no \$minpipesize in $syncoid\n";
+$minpipesize = eval $size;
+
+my @subs;
+foreach my $name ('buildsynccmd', 'escapeshellparam') {
+	my ($body) = $src =~ /^(sub \Q$name\E \{.*?^\})$/ms or die "no sub $name in $syncoid\n";
+	push @subs, $body;
+}
+eval join("\n", @subs);
+die "cannot load subs: $@" if $@;
+
+my $failed = 0;
+sub check {
+	my ($desc, $pvsize, $want) = @_;
+	my $cmd = buildsynccmd('zfs send -I a b', 'zfs receive -s -F t', $pvsize, 1, 1);
+	foreach my $stage ('lzop', 'mbuffer') {
+		my $got = ($cmd =~ /\b\Q$stage\E\b/) ? 1 : 0;
+		next if $got == $want;
+		print "FAIL: $desc: expected " . ($want ? '' : 'no ') . "$stage in: $cmd\n";
+		$failed = 1;
+	}
+	# pv is not size gated - progress reporting stays either way
+	if ($cmd !~ /\bpv\b/) {
+		print "FAIL: $desc: pv missing from: $cmd\n";
+		$failed = 1;
+	}
+}
+
+check('small transfer', $minpipesize - 1, 0);
+check('threshold transfer', $minpipesize, 1);
+check('large transfer', 100 * $minpipesize, 1);
+check('unknown size', 0, 1);
+
+print $failed ? "FAILED\n" : "PASS\n";
+exit $failed;


### PR DESCRIPTION
Every send gets the full pipeline regardless of size, so moving a few KB of metadata still starts a compressor plus an mbuffer on each end, and each mbuffer reserves --mbuffer-size up front (16M default, and users raise it: 128M here). For recursive runs where most datasets have almost no new data, the setup costs more than the transfer.

Compression and all mbuffer stages are skipped when the estimated send size is under 1 MiB. An estimate of 0 means unknown size, so the pipeline is kept there. pv is deliberately not gated, so progress output is unchanged. This mirrors what bzfs does with its min_pipe_transfer_size.

The threshold is a constant rather than a CLI flag; happy to add --min-pipe-size if you want it tunable.

Includes tests/syncoid/015_min_pipe_size, which extracts buildsynccmd() from syncoid and checks stage selection just below the threshold, at it, well above it, and for unknown size. Needs neither root nor a pool, so it runs in the existing runner without a zpool image.